### PR TITLE
Fixes path and non-root user issues with the installer

### DIFF
--- a/cmd/karavictl/cmd/cluster_info.go
+++ b/cmd/karavictl/cmd/cluster_info.go
@@ -32,7 +32,7 @@ var clusterInfoCmd = &cobra.Command{
 		if v, _ := cmd.Flags().GetBool("watch"); v {
 			cmdArgs = append(cmdArgs, "--watch")
 		}
-		kCmd := exec.Command("k3s", cmdArgs...)
+		kCmd := exec.Command(K3sPath, cmdArgs...)
 		kCmd.Stdout = os.Stdout
 		err := kCmd.Start()
 		if err != nil {

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -60,7 +60,7 @@ func init() {
 
 // GetAuthorizedStorageSystems returns list of storage systems added to authorization
 func GetAuthorizedStorageSystems() (map[string]Storage, error) {
-	k3sCmd := execCommandContext(context.Background(), "k3s", "kubectl", "get",
+	k3sCmd := execCommandContext(context.Background(), K3sPath, "kubectl", "get",
 		"--namespace=karavi",
 		"--output=json",
 		"secret/karavi-storage-secret")
@@ -96,7 +96,7 @@ func GetAuthorizedStorageSystems() (map[string]Storage, error) {
 func GetRoles() (map[string][]Role, error) {
 
 	ctx := context.Background()
-	k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+	k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 		"--namespace=karavi",
 		"--output=json",
 		"configmap/common")

--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -95,7 +95,7 @@ func modifyCommonConfigMap(roles map[string][]Role) error {
 default roles = {}
 roles = ` + string(data))
 
-	createCmd := execCommandContext(context.Background(), "k3s",
+	createCmd := execCommandContext(context.Background(), K3sPath,
 		"kubectl",
 		"create",
 		"configmap",
@@ -104,7 +104,7 @@ roles = ` + string(data))
 		"-n", "karavi",
 		"--dry-run=client",
 		"-o", "yaml")
-	applyCmd := execCommandContext(context.Background(), "k3s", "kubectl", "apply", "-f", "-")
+	applyCmd := execCommandContext(context.Background(), K3sPath, "kubectl", "apply", "-f", "-")
 
 	pr, pw := io.Pipe()
 	createCmd.Stdout = pw

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -24,6 +24,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	K3sPath = "/usr/local/bin/k3s" // Expected path to the k3s binary.
+)
+
 var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -109,7 +109,7 @@ var storageCreateCmd = &cobra.Command{
 		epURL.Scheme = "https"
 
 		// Get the current list of registered storage systems
-		k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
 			"--output=json",
 			"secret/karavi-storage-secret")
@@ -222,13 +222,13 @@ var storageCreateCmd = &cobra.Command{
 			errAndExit(err)
 		}
 
-		crtCmd := execCommandContext(ctx, "k3s", "kubectl", "create",
+		crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
 			"--namespace=karavi",
 			"secret", "generic", "karavi-storage-secret",
 			fmt.Sprintf("--from-file=storage-systems.yaml=%s", tmpFile.Name()),
 			"--output=yaml",
 			"--dry-run=client")
-		appCmd := execCommandContext(ctx, "k3s", "kubectl", "apply", "-f", "-")
+		appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
 
 		if err := pipeCommands(crtCmd, appCmd); err != nil {
 			errAndExit(err)

--- a/cmd/karavictl/cmd/storage_delete.go
+++ b/cmd/karavictl/cmd/storage_delete.go
@@ -55,7 +55,7 @@ var deleteCmd = &cobra.Command{
 
 		// Get the current resource
 
-		k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
 			"--output=json",
 			"secret/karavi-storage-secret")
@@ -128,13 +128,13 @@ var deleteCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		crtCmd := execCommandContext(ctx, "k3s", "kubectl", "create",
+		crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
 			"--namespace=karavi",
 			"secret", "generic", "karavi-storage-secret",
 			fmt.Sprintf("--from-file=storage-systems.yaml=%s", tmpFile.Name()),
 			"--output=yaml",
 			"--dry-run=client")
-		appCmd := execCommandContext(ctx, "k3s", "kubectl", "apply", "-f", "-")
+		appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
 
 		if err := pipeCommands(crtCmd, appCmd); err != nil {
 			log.Fatal(err)

--- a/cmd/karavictl/cmd/storage_get.go
+++ b/cmd/karavictl/cmd/storage_get.go
@@ -43,7 +43,7 @@ var getCmd = &cobra.Command{
 		}
 
 		// Get the current list of registered storage systems
-		k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
 			"--output=json",
 			"secret/karavi-storage-secret")

--- a/cmd/karavictl/cmd/storage_list.go
+++ b/cmd/karavictl/cmd/storage_list.go
@@ -33,7 +33,7 @@ var listCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
 			"--output=json",
 			"secret/karavi-storage-secret")

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -71,7 +71,7 @@ var storageUpdateCmd = &cobra.Command{
 
 		// TODO(ian): Check for password-stdin
 
-		k3sCmd := execCommandContext(ctx, "k3s", "kubectl", "get",
+		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
 			"--output=json",
 			"secret/karavi-storage-secret")
@@ -149,13 +149,13 @@ var storageUpdateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		crtCmd := execCommandContext(ctx, "k3s", "kubectl", "create",
+		crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
 			"--namespace=karavi",
 			"secret", "generic", "karavi-storage-secret",
 			fmt.Sprintf("--from-file=storage-systems.yaml=%s", tmpFile.Name()),
 			"--output=yaml",
 			"--dry-run=client")
-		appCmd := execCommandContext(ctx, "k3s", "kubectl", "apply", "-f", "-")
+		appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
 
 		if err := pipeCommands(crtCmd, appCmd); err != nil {
 			log.Fatal(err)

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -38,7 +38,13 @@ then
 	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s-airgap-images-$ARCH.tar
 fi
 
-# Save all referenced images into a tarball
+# Pull all 3rd party images to ensure they exist locally.
+# You can also run "make dep" to pull these down without 
+# having to run this script.
+for image in $(grep "image: docker.io" deployment.yaml | awk -F' ' '{ print $2 }' | xargs echo); do
+  docker pull $image
+done
+# Save all referenced images into a tarball.
 grep "image: " deployment.yaml | awk -F' ' '{ print $2 }' | xargs docker save -o $CRED_SHIELD_IMAGES_TAR
 
 

--- a/policies/policy-install.sh
+++ b/policies/policy-install.sh
@@ -3,8 +3,9 @@ set -x
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
 
 cd "$(dirname "$0")"
-k3s kubectl create configmap common -n karavi --from-file=./common.rego --save-config
-k3s kubectl create configmap secret -n karavi --from-file=./secret.rego --save-config
-k3s kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config
-k3s kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config
-k3s kubectl create configmap authz -n karavi --from-file=./url.rego --save-config
+K3S=/usr/local/bin/k3s
+$K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config
+$K3S kubectl create configmap secret -n karavi --from-file=./secret.rego --save-config
+$K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config
+$K3S kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config
+$K3S kubectl create configmap authz -n karavi --from-file=./url.rego --save-config


### PR DESCRIPTION
# Description

This PR fixes a few issues around deployment:

1. Deployment issues encountered when the host used does not have `/usr/local/bin/` in their `PATH`.  Various Karavi commands incorrectly made the assumption that this was never the case, causing the "k3s" command to not be found.
2. Building the codebase without first pulling the required third-party images would give a subtle error that is hard to debug.  We now provide a `make dep` target, and third-party images are now pulled as part of the `dist` target.
3. Non-root user issues: the installer must be ran as root or with sudo, but subsequent karavictl commands should not.  If ran as sudo, we utilize the SUDO_UID/GID env vars to determine who the effective user is and chmod the kubeconfig appropriately (it has root permissions by default, requiring `sudo karavictl` on some commands that access the kubeconfig).  

## Testing

ok      karavi-authorization/deploy     0.185s  coverage: 92.1% of statements


# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|  #10 |

# Checklist:

- [x ] I have performed a self-review of my own changes.