### PR TITLE
Makes the storage password prompt more descriptive

### DIFF
--- a/cmd/karavictl/cmd/test_utils.go
+++ b/cmd/karavictl/cmd/test_utils.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // Allows for overriding as part of testing.
@@ -28,6 +29,7 @@ var (
 	CreateTenantServiceClient = createTenantServiceClient
 	JSONOutput                = jsonOutput
 	osExit                    = os.Exit
+	termReadPassword          = term.ReadPassword
 )
 
 func setFlag(t *testing.T, cmd *cobra.Command, name, value string) {


### PR DESCRIPTION
# Description

When adding a storage system to Karavi-Authorization, the password prompt is simply "Enter password:".  When scripting `karavictl` commands this may lead to confusion as to which system the prompt relates to.

This PR makes the prompt more descriptive, e.g.

```
$ karavictl storage create --type powerflex --system-id=542a2d5f5122210f --user admin --endpoint 10.0.0.1 --insecure
Enter password for https://admin@10.0.0.1:
```

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.
- [X] I have ran E2E manually.