### PR TITLE
Allows docker to be used for building the RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 bin/
 deploy/dist/
-deploy/rpmbuild/BUILD
-deploy/rpmbuild/BUILDROOT
-deploy/rpmbuild/RPMS
-deploy/rpmbuild/SRPMS
-deploy/rpmbuild/SOURCES
+deploy/rpm/*
+
+!deploy/rpm/pkg
+
+!deploy/rpm/SPECS/
+!deploy/rpm/SPECS/*

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@ build-installer:
 	go build -tags=prod -o ./bin ./deploy/
 
 .PHONY: rpm
-rpm: 
-    # Requires rpm-build package
-	rpmbuild --define "_topdir `pwd`/deploy/rpmbuild" -v -bb ./deploy/rpmbuild/SPECS/karavi-authorization.spec
+rpm:
+	docker run \
+		-v $$PWD/deploy/rpm/pkg:/srv/pkg \
+		-v $$PWD/bin/deploy:/home/builder/rpm/deploy \
+		-v $$PWD/deploy/rpm:/home/builder/rpm \
+		rpmbuild/centos7
+
 
 .PHONY: redeploy
 redeploy: build docker

--- a/deploy/rpm/SPECS/karavi-authorization.spec
+++ b/deploy/rpm/SPECS/karavi-authorization.spec
@@ -9,16 +9,15 @@ License:        ASL 2.0
 Install Karavi Authorization package
 
 %install
-mkdir -p $RPM_BUILD_ROOT%{_bindir}/karavi-authorization
-echo "The current dir is: $(pwd)"
-cp ../../../bin/deploy $RPM_BUILD_ROOT/%{_bindir}/karavi-authorization/.
+mkdir -p $RPM_BUILD_ROOT%{_tmppath}
+cp deploy $RPM_BUILD_ROOT%{_tmppath}
 
 %files
-%{_bindir}/karavi-authorization/deploy
+%{_tmppath}/deploy
 
 %post
 echo "Installing %{name}-%{version}.%{release}"
-%{_bindir}/karavi-authorization/deploy
+%{_tmppath}/deploy
 echo "Installation Complete"
 
 %preun
@@ -28,5 +27,5 @@ rm -rf /var/lib/rancher/k3s/agent/images
 rm -rf /var/lib/rancher/k3s/server/manifests
 
 %postun
-rm -rf %{_bindir}/karavi-authorization
+rm -rf %{_tmppath}/deploy
 echo "Uninstall Complete"

--- a/deploy/rpm/pkg
+++ b/deploy/rpm/pkg
@@ -1,0 +1,2 @@
+rpmbuild --define "_topdir /home/builder/rpm" -v -bb /home/builder/rpm/SPECS/karavi-authorization.spec
+


### PR DESCRIPTION
# Description

This PR improves on the RPM build step to use docker rather than require `rpmbuild` be available directly, which is troublesome when on non-RHEL based operating systems.

* Uses `rpmbuild/centos7` docker container.
* Updates the spec file to place the installer into `/var/tmp` instead of `/usr/bin` (it's only intended to be executed once).
* Updates the .gitignore file accordingly.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.
- [X] I have ran E2E manually.