### PR TITLE
Support injection of Observability to gather SDC, Volume, and StorageClass metrics

### DIFF
--- a/cmd/karavictl/cmd/testdata/kubectl_get_all_in_karavi_observability.yaml
+++ b/cmd/karavictl/cmd/testdata/kubectl_get_all_in_karavi_observability.yaml
@@ -1,0 +1,1786 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: default
+      kubernetes.io/service-account.uid: fa177924-5311-45e5-964f-0c87e2d229bd
+    creationTimestamp: "2021-03-08T13:55:21Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-08T13:55:21Z"
+    name: default-token-b75n5
+    namespace: karavi
+    resourceVersion: "1893517"
+    selfLink: /api/v1/namespaces/karavi/secrets/default-token-b75n5
+    uid: 5db7f971-a3a2-407b-978f-94d533cb89b5
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: karavi-observability-cert-manager-cainjector
+      kubernetes.io/service-account.uid: 079f1b94-8c41-4299-a2d9-02722df22fe2
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    name: karavi-observability-cert-manager-cainjector-token-4w6wx
+    namespace: karavi
+    resourceVersion: "2291054"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-cert-manager-cainjector-token-4w6wx
+    uid: 3dc263ea-0d6e-4f87-af8c-5b4b3b0b324b
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: karavi-observability-cert-manager
+      kubernetes.io/service-account.uid: 94a16fd8-5eb1-4acb-b8eb-0a0a31f73a46
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    name: karavi-observability-cert-manager-token-wthgd
+    namespace: karavi
+    resourceVersion: "2291066"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-cert-manager-token-wthgd
+    uid: b3a7f6a6-5cb5-4a30-b75d-2c9672b8a745
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    tls.crt: c2VjcmV0
+    tls.key: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      cert-manager.io/allow-direct-injection: "true"
+    creationTimestamp: "2021-03-08T13:55:23Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:tls.crt: {}
+          f:tls.key: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:cert-manager.io/allow-direct-injection: {}
+        f:type: {}
+      manager: webhook
+      operation: Update
+      time: "2021-03-08T13:55:23Z"
+    name: karavi-observability-cert-manager-webhook-ca
+    namespace: karavi
+    resourceVersion: "1893718"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-cert-manager-webhook-ca
+    uid: 86a852c5-e17e-4fbd-8a69-1f1792bfc37b
+  type: Opaque
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: karavi-observability-cert-manager-webhook
+      kubernetes.io/service-account.uid: 615551a4-ab74-4ad1-b10b-c535721d48f9
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    name: karavi-observability-cert-manager-webhook-token-bhxf9
+    namespace: karavi
+    resourceVersion: "2291063"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-cert-manager-webhook-token-bhxf9
+    uid: d4144814-50d5-46bb-9ef9-46e34fcc1756
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: karavi-observability-metrics-powerflex-controller
+      kubernetes.io/service-account.uid: daed04ad-6430-44f2-8293-9bf1b4999ee7
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    name: karavi-observability-metrics-powerflex-controller-token-hzrx8
+    namespace: karavi
+    resourceVersion: "2291067"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-metrics-powerflex-controller-token-hzrx8
+    uid: 277071e5-02d7-4269-bfdc-2c2ce3c71d63
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    namespace: c2VjcmV0
+    token: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      kubernetes.io/service-account.name: karavi-observability-topology-controller
+      kubernetes.io/service-account.uid: 17769f31-916a-4707-8f8d-d457baeab782
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:namespace: {}
+          f:token: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:kubernetes.io/service-account.name: {}
+            f:kubernetes.io/service-account.uid: {}
+        f:type: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    name: karavi-observability-topology-controller-token-n52w9
+    namespace: karavi
+    resourceVersion: "2291052"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-observability-topology-controller-token-n52w9
+    uid: f474c1ba-a189-457f-b04e-e114410f1670
+  type: kubernetes.io/service-account-token
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    tls.crt: c2VjcmV0
+    tls.key: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      cert-manager.io/alt-names: karavi-topology,karavi-topology.karavi.svc.kubernetes.local
+      cert-manager.io/certificate-name: karavi-topology
+      cert-manager.io/common-name: ""
+      cert-manager.io/ip-sans: ""
+      cert-manager.io/issuer-group: cert-manager.io
+      cert-manager.io/issuer-kind: Issuer
+      cert-manager.io/issuer-name: selfsigned-issuer
+      cert-manager.io/uri-sans: ""
+    creationTimestamp: "2021-03-08T13:56:29Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:tls.crt: {}
+          f:tls.key: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:cert-manager.io/alt-names: {}
+            f:cert-manager.io/certificate-name: {}
+            f:cert-manager.io/common-name: {}
+            f:cert-manager.io/ip-sans: {}
+            f:cert-manager.io/issuer-group: {}
+            f:cert-manager.io/issuer-kind: {}
+            f:cert-manager.io/issuer-name: {}
+            f:cert-manager.io/uri-sans: {}
+        f:type: {}
+      manager: controller
+      operation: Update
+      time: "2021-03-08T13:56:29Z"
+    name: karavi-topology-tls
+    namespace: karavi
+    resourceVersion: "1894038"
+    selfLink: /api/v1/namespaces/karavi/secrets/karavi-topology-tls
+    uid: 580808b4-cbf2-4284-b466-6851fb2c49af
+  type: kubernetes.io/tls
+- apiVersion: v1
+  data:
+    ca.crt: c2VjcmV0
+    tls.crt: c2VjcmV0
+    tls.key: c2VjcmV0
+  kind: Secret
+  metadata:
+    annotations:
+      cert-manager.io/alt-names: otel-collector,otel-collector.karavi.svc.kubernetes.local
+      cert-manager.io/certificate-name: otel-collector
+      cert-manager.io/common-name: ""
+      cert-manager.io/ip-sans: ""
+      cert-manager.io/issuer-group: cert-manager.io
+      cert-manager.io/issuer-kind: Issuer
+      cert-manager.io/issuer-name: selfsigned-issuer
+      cert-manager.io/uri-sans: ""
+    creationTimestamp: "2021-03-08T13:56:29Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:ca.crt: {}
+          f:tls.crt: {}
+          f:tls.key: {}
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:cert-manager.io/alt-names: {}
+            f:cert-manager.io/certificate-name: {}
+            f:cert-manager.io/common-name: {}
+            f:cert-manager.io/ip-sans: {}
+            f:cert-manager.io/issuer-group: {}
+            f:cert-manager.io/issuer-kind: {}
+            f:cert-manager.io/issuer-name: {}
+            f:cert-manager.io/uri-sans: {}
+        f:type: {}
+      manager: controller
+      operation: Update
+      time: "2021-03-08T13:56:29Z"
+    name: otel-collector-tls
+    namespace: karavi
+    resourceVersion: "1894037"
+    selfLink: /api/v1/namespaces/karavi/secrets/otel-collector-tls
+    uid: 92d1de85-5d87-4976-bf4c-c1e5f550111d
+  type: kubernetes.io/tls
+- apiVersion: v1
+  data:
+    release: cmVsZWFzZQo=
+  kind: Secret
+  metadata:
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    labels:
+      modifiedAt: "1615321753"
+      name: karavi-observability
+      owner: helm
+      status: deployed
+      version: "1"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:release: {}
+        f:metadata:
+          f:labels:
+            .: {}
+            f:modifiedAt: {}
+            f:name: {}
+            f:owner: {}
+            f:status: {}
+            f:version: {}
+        f:type: {}
+      manager: helm
+      operation: Update
+      time: "2021-03-09T20:29:13Z"
+    name: sh.helm.release.v1.karavi-observability.v1
+    namespace: karavi
+    resourceVersion: "2291178"
+    selfLink: /api/v1/namespaces/karavi/secrets/sh.helm.release.v1.karavi-observability.v1
+    uid: 9d9449b3-fc42-4f69-8311-56f317a42607
+  type: helm.sh/release.v1
+- apiVersion: v1
+  data:
+    MDM: bWRtLTEsbWRtLTI=
+    config: W3sidXNlcm5hbWUiOiJ1c2VybmFtZSIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJzeXN0ZW1JRCI6ImFiY2RlZmcwMTIzNDU2Nzg5IiwiZW5kcG9pbnQiOiJodHRwczovL3Bvd2VyZmxleC1pcCIsImluc2VjdXJlIjp0cnVlLCJpc0RlZmF1bHQiOnRydWUsIm1kbSI6Im1kbS0xLG1kbS0yIn1d
+  kind: Secret
+  metadata:
+    creationTimestamp: "2021-03-09T20:29:10Z"
+    managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:data:
+          .: {}
+          f:MDM: {}
+          f:config: {}
+        f:type: {}
+      manager: kubectl
+      operation: Update
+      time: "2021-03-09T20:29:10Z"
+    name: vxflexos-config
+    namespace: karavi
+    resourceVersion: "2291006"
+    selfLink: /api/v1/namespaces/karavi/secrets/vxflexos-config
+    uid: 1f1879b5-9c7e-49ae-8a1a-bb629b89ac7b
+  type: Opaque
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: karavi_metrics_powerflex
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:labels:
+                .: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/name: {}
+            f:spec:
+              f:containers:
+                k:{"name":"karavi-metrics-powerflex"}:
+                  .: {}
+                  f:env:
+                    .: {}
+                    k:{"name":"POWERFLEX_METRICS_ENDPOINT"}:
+                      .: {}
+                      f:name: {}
+                      f:value: {}
+                    k:{"name":"POWERFLEX_METRICS_NAMESPACE"}:
+                      .: {}
+                      f:name: {}
+                      f:valueFrom:
+                        .: {}
+                        f:fieldRef:
+                          .: {}
+                          f:apiVersion: {}
+                          f:fieldPath: {}
+                    k:{"name":"TLS_ENABLED"}:
+                      .: {}
+                      f:name: {}
+                      f:value: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+                  f:volumeMounts:
+                    .: {}
+                    k:{"mountPath":"/etc/config"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                    k:{"mountPath":"/etc/ssl/certs"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                      f:readOnly: {}
+                    k:{"mountPath":"/vxflexos-config"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:serviceAccount: {}
+              f:serviceAccountName: {}
+              f:terminationGracePeriodSeconds: {}
+              f:volumes:
+                .: {}
+                k:{"name":"karavi-metrics-powerflex-configmap"}:
+                  .: {}
+                  f:configMap:
+                    .: {}
+                    f:defaultMode: {}
+                    f:name: {}
+                  f:name: {}
+                k:{"name":"tls-secret"}:
+                  .: {}
+                  f:name: {}
+                  f:secret:
+                    .: {}
+                    f:defaultMode: {}
+                    f:items: {}
+                    f:secretName: {}
+                k:{"name":"vxflexos-config"}:
+                  .: {}
+                  f:name: {}
+                  f:secret:
+                    .: {}
+                    f:defaultMode: {}
+                    f:secretName: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:17Z"
+    name: karavi-metrics-powerflex
+    namespace: karavi
+    resourceVersion: "2291297"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/karavi-metrics-powerflex
+    uid: d8641e94-21db-4a1b-bce1-4fa6097c81e9
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: karavi_metrics_powerflex
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/name: karavi_metrics_powerflex
+      spec:
+        containers:
+        - env:
+          - name: POWERFLEX_METRICS_ENDPOINT
+            value: karavi-metrics-powerflex
+          - name: POWERFLEX_METRICS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: TLS_ENABLED
+            value: "true"
+          image: image-repository:5000/karavi-metrics-powerflex:latest
+          imagePullPolicy: Always
+          name: karavi-metrics-powerflex
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /vxflexos-config
+            name: vxflexos-config
+          - mountPath: /etc/ssl/certs
+            name: tls-secret
+            readOnly: true
+          - mountPath: /etc/config
+            name: karavi-metrics-powerflex-configmap
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccount: karavi-observability-metrics-powerflex-controller
+        serviceAccountName: karavi-observability-metrics-powerflex-controller
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: vxflexos-config
+          secret:
+            defaultMode: 420
+            secretName: vxflexos-config
+        - name: tls-secret
+          secret:
+            defaultMode: 420
+            items:
+            - key: tls.crt
+              path: cert.crt
+            secretName: otel-collector-tls
+        - configMap:
+            defaultMode: 420
+            name: karavi-metrics-powerflex-configmap
+          name: karavi-metrics-powerflex-configmap
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:17Z"
+      lastUpdateTime: "2021-03-09T20:29:17Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:13Z"
+      lastUpdateTime: "2021-03-09T20:29:17Z"
+      message: ReplicaSet "karavi-metrics-powerflex-cf848746d" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app: cert-manager
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: cert-manager
+      helm.sh/chart: cert-manager-v1.1.0
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app: {}
+            f:app.kubernetes.io/component: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+            f:helm.sh/chart: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/component: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:annotations:
+                .: {}
+                f:prometheus.io/path: {}
+                f:prometheus.io/port: {}
+                f:prometheus.io/scrape: {}
+              f:labels:
+                .: {}
+                f:app: {}
+                f:app.kubernetes.io/component: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/managed-by: {}
+                f:app.kubernetes.io/name: {}
+                f:helm.sh/chart: {}
+            f:spec:
+              f:containers:
+                k:{"name":"cert-manager"}:
+                  .: {}
+                  f:args: {}
+                  f:env:
+                    .: {}
+                    k:{"name":"POD_NAMESPACE"}:
+                      .: {}
+                      f:name: {}
+                      f:valueFrom:
+                        .: {}
+                        f:fieldRef:
+                          .: {}
+                          f:apiVersion: {}
+                          f:fieldPath: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:ports:
+                    .: {}
+                    k:{"containerPort":9402,"protocol":"TCP"}:
+                      .: {}
+                      f:containerPort: {}
+                      f:protocol: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:serviceAccount: {}
+              f:serviceAccountName: {}
+              f:terminationGracePeriodSeconds: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:15Z"
+    name: karavi-observability-cert-manager
+    namespace: karavi
+    resourceVersion: "2291269"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/karavi-observability-cert-manager
+    uid: ec6d9257-28d4-4510-80e8-21bdd904915c
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: cert-manager
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        annotations:
+          prometheus.io/path: /metrics
+          prometheus.io/port: "9402"
+          prometheus.io/scrape: "true"
+        creationTimestamp: null
+        labels:
+          app: cert-manager
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: cert-manager
+          helm.sh/chart: cert-manager-v1.1.0
+      spec:
+        containers:
+        - args:
+          - --v=2
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=kube-system
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          image: quay.io/jetstack/cert-manager-controller:v1.1.0
+          imagePullPolicy: IfNotPresent
+          name: cert-manager
+          ports:
+          - containerPort: 9402
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccount: karavi-observability-cert-manager
+        serviceAccountName: karavi-observability-cert-manager
+        terminationGracePeriodSeconds: 30
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:15Z"
+      lastUpdateTime: "2021-03-09T20:29:15Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:12Z"
+      lastUpdateTime: "2021-03-09T20:29:15Z"
+      message: ReplicaSet "karavi-observability-cert-manager-6f56d6cd5f" has successfully
+        progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app: cainjector
+      app.kubernetes.io/component: cainjector
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: cainjector
+      helm.sh/chart: cert-manager-v1.1.0
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app: {}
+            f:app.kubernetes.io/component: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+            f:helm.sh/chart: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/component: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:labels:
+                .: {}
+                f:app: {}
+                f:app.kubernetes.io/component: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/managed-by: {}
+                f:app.kubernetes.io/name: {}
+                f:helm.sh/chart: {}
+            f:spec:
+              f:containers:
+                k:{"name":"cert-manager"}:
+                  .: {}
+                  f:args: {}
+                  f:env:
+                    .: {}
+                    k:{"name":"POD_NAMESPACE"}:
+                      .: {}
+                      f:name: {}
+                      f:valueFrom:
+                        .: {}
+                        f:fieldRef:
+                          .: {}
+                          f:apiVersion: {}
+                          f:fieldPath: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:serviceAccount: {}
+              f:serviceAccountName: {}
+              f:terminationGracePeriodSeconds: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:14Z"
+    name: karavi-observability-cert-manager-cainjector
+    namespace: karavi
+    resourceVersion: "2291239"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/karavi-observability-cert-manager-cainjector
+    uid: 588f82a2-ef7a-4ff7-bf48-ad4cfcdb33e7
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: cainjector
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: cainjector
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: cainjector
+          app.kubernetes.io/component: cainjector
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: cainjector
+          helm.sh/chart: cert-manager-v1.1.0
+      spec:
+        containers:
+        - args:
+          - --v=2
+          - --leader-election-namespace=kube-system
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          image: quay.io/jetstack/cert-manager-cainjector:v1.1.0
+          imagePullPolicy: IfNotPresent
+          name: cert-manager
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccount: karavi-observability-cert-manager-cainjector
+        serviceAccountName: karavi-observability-cert-manager-cainjector
+        terminationGracePeriodSeconds: 30
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:14Z"
+      lastUpdateTime: "2021-03-09T20:29:14Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:12Z"
+      lastUpdateTime: "2021-03-09T20:29:14Z"
+      message: ReplicaSet "karavi-observability-cert-manager-cainjector-7dbcc457bd"
+        has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app: webhook
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: webhook
+      helm.sh/chart: cert-manager-v1.1.0
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app: {}
+            f:app.kubernetes.io/component: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+            f:helm.sh/chart: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/component: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:labels:
+                .: {}
+                f:app: {}
+                f:app.kubernetes.io/component: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/managed-by: {}
+                f:app.kubernetes.io/name: {}
+                f:helm.sh/chart: {}
+            f:spec:
+              f:containers:
+                k:{"name":"cert-manager"}:
+                  .: {}
+                  f:args: {}
+                  f:env:
+                    .: {}
+                    k:{"name":"POD_NAMESPACE"}:
+                      .: {}
+                      f:name: {}
+                      f:valueFrom:
+                        .: {}
+                        f:fieldRef:
+                          .: {}
+                          f:apiVersion: {}
+                          f:fieldPath: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:livenessProbe:
+                    .: {}
+                    f:failureThreshold: {}
+                    f:httpGet:
+                      .: {}
+                      f:path: {}
+                      f:port: {}
+                      f:scheme: {}
+                    f:initialDelaySeconds: {}
+                    f:periodSeconds: {}
+                    f:successThreshold: {}
+                    f:timeoutSeconds: {}
+                  f:name: {}
+                  f:ports:
+                    .: {}
+                    k:{"containerPort":10250,"protocol":"TCP"}:
+                      .: {}
+                      f:containerPort: {}
+                      f:name: {}
+                      f:protocol: {}
+                  f:readinessProbe:
+                    .: {}
+                    f:failureThreshold: {}
+                    f:httpGet:
+                      .: {}
+                      f:path: {}
+                      f:port: {}
+                      f:scheme: {}
+                    f:initialDelaySeconds: {}
+                    f:periodSeconds: {}
+                    f:successThreshold: {}
+                    f:timeoutSeconds: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:serviceAccount: {}
+              f:serviceAccountName: {}
+              f:terminationGracePeriodSeconds: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:22Z"
+    name: karavi-observability-cert-manager-webhook
+    namespace: karavi
+    resourceVersion: "2291317"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/karavi-observability-cert-manager-webhook
+    uid: abf18b3b-c4a3-49c5-932f-266986f90255
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: webhook
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: webhook
+          app.kubernetes.io/component: webhook
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: webhook
+          helm.sh/chart: cert-manager-v1.1.0
+      spec:
+        containers:
+        - args:
+          - --v=2
+          - --secure-port=10250
+          - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
+          - --dynamic-serving-ca-secret-name=karavi-observability-cert-manager-webhook-ca
+          - --dynamic-serving-dns-names=karavi-observability-cert-manager-webhook,karavi-observability-cert-manager-webhook.karavi,karavi-observability-cert-manager-webhook.karavi.svc
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          image: quay.io/jetstack/cert-manager-webhook:v1.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: cert-manager
+          ports:
+          - containerPort: 10250
+            name: https
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccount: karavi-observability-cert-manager-webhook
+        serviceAccountName: karavi-observability-cert-manager-webhook
+        terminationGracePeriodSeconds: 30
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:22Z"
+      lastUpdateTime: "2021-03-09T20:29:22Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:12Z"
+      lastUpdateTime: "2021-03-09T20:29:22Z"
+      message: ReplicaSet "karavi-observability-cert-manager-webhook-5b7f679ff" has
+        successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: karavi_topology
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:labels:
+                .: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/name: {}
+            f:spec:
+              f:containers:
+                k:{"name":"karavi-topology"}:
+                  .: {}
+                  f:env:
+                    .: {}
+                    k:{"name":"PORT"}:
+                      .: {}
+                      f:name: {}
+                      f:value: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+                  f:volumeMounts:
+                    .: {}
+                    k:{"mountPath":"/certs"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                    k:{"mountPath":"/etc/config"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:serviceAccount: {}
+              f:serviceAccountName: {}
+              f:terminationGracePeriodSeconds: {}
+              f:volumes:
+                .: {}
+                k:{"name":"karavi-topology-configmap"}:
+                  .: {}
+                  f:configMap:
+                    .: {}
+                    f:defaultMode: {}
+                    f:name: {}
+                  f:name: {}
+                k:{"name":"karavi-topology-secret-volume"}:
+                  .: {}
+                  f:name: {}
+                  f:secret:
+                    .: {}
+                    f:defaultMode: {}
+                    f:items: {}
+                    f:secretName: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:16Z"
+    name: karavi-topology
+    namespace: karavi
+    resourceVersion: "2291281"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/karavi-topology
+    uid: 0957a2cc-6604-4b30-9a8d-b32e96bafccb
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: karavi_topology
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/name: karavi_topology
+      spec:
+        containers:
+        - env:
+          - name: PORT
+            value: "8443"
+          image: image-repository:5000/karavi-topology:latest
+          imagePullPolicy: Always
+          name: karavi-topology
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /certs
+            name: karavi-topology-secret-volume
+          - mountPath: /etc/config
+            name: karavi-topology-configmap
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccount: karavi-observability-topology-controller
+        serviceAccountName: karavi-observability-topology-controller
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: karavi-topology-secret-volume
+          secret:
+            defaultMode: 420
+            items:
+            - key: tls.crt
+              path: localhost.crt
+            - key: tls.key
+              path: localhost.key
+            secretName: karavi-topology-tls
+        - configMap:
+            defaultMode: 420
+            name: karavi-topology-configmap
+          name: karavi-topology-configmap
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:16Z"
+      lastUpdateTime: "2021-03-09T20:29:16Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:12Z"
+      lastUpdateTime: "2021-03-09T20:29:16Z"
+      message: ReplicaSet "karavi-topology-7fff464f7f" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      meta.helm.sh/release-name: karavi-observability
+      meta.helm.sh/release-namespace: karavi
+    creationTimestamp: "2021-03-09T20:29:12Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/instance: karavi-observability
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: otel-collector
+    managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:meta.helm.sh/release-name: {}
+            f:meta.helm.sh/release-namespace: {}
+          f:labels:
+            .: {}
+            f:app.kubernetes.io/instance: {}
+            f:app.kubernetes.io/managed-by: {}
+            f:app.kubernetes.io/name: {}
+        f:spec:
+          f:progressDeadlineSeconds: {}
+          f:replicas: {}
+          f:revisionHistoryLimit: {}
+          f:selector:
+            f:matchLabels:
+              .: {}
+              f:app.kubernetes.io/instance: {}
+              f:app.kubernetes.io/name: {}
+          f:strategy:
+            f:rollingUpdate:
+              .: {}
+              f:maxSurge: {}
+              f:maxUnavailable: {}
+            f:type: {}
+          f:template:
+            f:metadata:
+              f:labels:
+                .: {}
+                f:app.kubernetes.io/instance: {}
+                f:app.kubernetes.io/name: {}
+            f:spec:
+              f:containers:
+                k:{"name":"nginx-proxy"}:
+                  .: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+                  f:volumeMounts:
+                    .: {}
+                    k:{"mountPath":"/etc/nginx/nginx.conf"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                      f:subPath: {}
+                    k:{"mountPath":"/etc/ssl/certs"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                k:{"name":"otel-collector"}:
+                  .: {}
+                  f:args: {}
+                  f:image: {}
+                  f:imagePullPolicy: {}
+                  f:name: {}
+                  f:resources: {}
+                  f:terminationMessagePath: {}
+                  f:terminationMessagePolicy: {}
+                  f:volumeMounts:
+                    .: {}
+                    k:{"mountPath":"/etc/otel-collector-config.yaml"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+                      f:subPath: {}
+                    k:{"mountPath":"/etc/ssl/certs"}:
+                      .: {}
+                      f:mountPath: {}
+                      f:name: {}
+              f:dnsPolicy: {}
+              f:restartPolicy: {}
+              f:schedulerName: {}
+              f:securityContext: {}
+              f:terminationGracePeriodSeconds: {}
+              f:volumes:
+                .: {}
+                k:{"name":"nginx-config"}:
+                  .: {}
+                  f:configMap:
+                    .: {}
+                    f:defaultMode: {}
+                    f:name: {}
+                  f:name: {}
+                k:{"name":"otel-collector-config"}:
+                  .: {}
+                  f:configMap:
+                    .: {}
+                    f:defaultMode: {}
+                    f:name: {}
+                  f:name: {}
+                k:{"name":"tls-secret"}:
+                  .: {}
+                  f:name: {}
+                  f:secret:
+                    .: {}
+                    f:defaultMode: {}
+                    f:items: {}
+                    f:secretName: {}
+      manager: Go-http-client
+      operation: Update
+      time: "2021-03-09T20:29:12Z"
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            f:deployment.kubernetes.io/revision: {}
+        f:status:
+          f:availableReplicas: {}
+          f:conditions:
+            .: {}
+            k:{"type":"Available"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+            k:{"type":"Progressing"}:
+              .: {}
+              f:lastTransitionTime: {}
+              f:lastUpdateTime: {}
+              f:message: {}
+              f:reason: {}
+              f:status: {}
+              f:type: {}
+          f:observedGeneration: {}
+          f:readyReplicas: {}
+          f:replicas: {}
+          f:updatedReplicas: {}
+      manager: kube-controller-manager
+      operation: Update
+      time: "2021-03-09T20:29:17Z"
+    name: otel-collector
+    namespace: karavi
+    resourceVersion: "2291287"
+    selfLink: /apis/apps/v1/namespaces/karavi/deployments/otel-collector
+    uid: fa22b71e-829b-4489-8bda-aae860e1c113
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: karavi-observability
+        app.kubernetes.io/name: otel-collector
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: karavi-observability
+          app.kubernetes.io/name: otel-collector
+      spec:
+        containers:
+        - image: nginx:1
+          imagePullPolicy: IfNotPresent
+          name: nginx-proxy
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/ssl/certs
+            name: tls-secret
+          - mountPath: /etc/nginx/nginx.conf
+            name: nginx-config
+            subPath: nginx.conf
+        - args:
+          - --config=/etc/otel-collector-config.yaml
+          image: otel/opentelemetry-collector:0.9.0
+          imagePullPolicy: IfNotPresent
+          name: otel-collector
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/otel-collector-config.yaml
+            name: otel-collector-config
+            subPath: otel-collector-config.yaml
+          - mountPath: /etc/ssl/certs
+            name: tls-secret
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: tls-secret
+          secret:
+            defaultMode: 420
+            items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+            secretName: otel-collector-tls
+        - configMap:
+            defaultMode: 420
+            name: nginx-config
+          name: nginx-config
+        - configMap:
+            defaultMode: 420
+            name: otel-collector-config
+          name: otel-collector-config
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-09T20:29:17Z"
+      lastUpdateTime: "2021-03-09T20:29:17Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-09T20:29:12Z"
+      lastUpdateTime: "2021-03-09T20:29:17Z"
+      message: ReplicaSet "otel-collector-6d9987566b" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/policies/url.rego
+++ b/policies/url.rego
@@ -24,6 +24,10 @@ allowlist = [
 		"GET /api/instances/Volume::[a-f0-9]+/$",
 		"POST /api/types/Volume/instances/action/queryIdByKey/",
 		"GET /api/instances/System::[a-f0-9]+/relationships/Sdc/",
+		"GET /api/instances/Sdc::[a-f0-9]+/relationships/Statistics/",
+		"GET /api/instances/Sdc::[a-f0-9]+/relationships/Volume/",
+		"GET /api/instances/Volume::[a-f0-9]+/relationships/Statistics/",
+		"GET /api/instances/StoragePool::[a-f0-9]+/relationships/Statistics/",
 		"POST /api/instances/Volume::[a-f0-9]+/action/addMappedSdc/",
 		"POST /api/instances/Volume::[a-f0-9]+/action/removeMappedSdc/",
 		"POST /api/instances/Volume::[a-f0-9]+/action/removeVolume/"


### PR DESCRIPTION
# Description

This pull request adds support for injecting the sidecar-proxy into Observability. The `karavictl inject` command will now support adding the sidecar-proxy into the `karavi-metrics-powerflex` Deployment which requires access to the PowerFlex API.

Example:
`kubectl get secrets,deployments -n karavi -o yaml | karavictl inject --image-addr <registry-ip>:5000/sidecar-proxy:latest --proxy-host <proxy-host-ip> | kubectl apply -f -`

Summary of changes:
- The inject command will first detect what is being injected (csi-powerflex driver or Observability) based on the list of Deployments and then inject the provided Deployment and/or DaemonSet with the sidecar.
- Use the namespace of the Deployment instead of hard-coded value of `vxflexos`.
- Updates the policy to allow API calls for querying Volume, SDC, and StorageClass metrics.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|   #39        |

# Checklist:

- [x] I have performed a self-review of my own changes.