### PR TITLE
Optional tracing and debug output

### DIFF
--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -27,6 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // CtxKey wraps the int type and is meant for context values
@@ -54,6 +56,12 @@ func Adapt(h http.Handler, mws ...Middleware) http.Handler {
 // OtelMW configures OpenTelemetry http instrumentation
 func OtelMW(tp trace.TracerProvider, op string, opts ...otelhttp.Option) Middleware {
 	return func(next http.Handler) http.Handler {
+		switch t := tp.(type) {
+		case *sdktrace.TracerProvider:
+			if t == nil {
+				return next
+			}
+		}
 		opts = append(opts, otelhttp.WithTracerProvider(tp))
 		return otelhttp.NewHandler(next, op, opts...)
 	}
@@ -67,7 +75,8 @@ func LoggingMW(log *logrus.Entry, showHTTPDump bool) Middleware {
 			if showHTTPDump {
 				b, err := httputil.DumpRequest(r, true)
 				if err != nil {
-					panic(err)
+					log.Printf("web: http dump request: %w", err)
+					return
 				}
 				log.Println(string(b))
 			}


### PR DESCRIPTION
# Description

This PR fixes the noisy log messages when otel attempts to send spans to a Zipkin that doesn't exist.

Additionally, the dumping of each HTTP request is based on the configuration field "web.showdebughttp".

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.