### PR TITLE
Pass in listen addr for gRPC tenant service

### DIFF
--- a/cmd/tenant-service/main.go
+++ b/cmd/tenant-service/main.go
@@ -29,15 +29,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	// DefaultListenAddr is the default port to listen on
-	DefaultListenAddr = "localhost:50051"
-)
-
 func main() {
 	var cfg struct {
-		Version string
-		Zipkin  struct {
+		GrpcListenAddr string
+		Version        string
+		Zipkin         struct {
 			CollectorURI string
 			ServiceName  string
 			Probability  float64
@@ -57,6 +53,8 @@ func main() {
 	cfgViper.SetConfigName("config")
 	cfgViper.AddConfigPath(".")
 	cfgViper.AddConfigPath("/etc/karavi-authorization/config/")
+
+	cfgViper.SetDefault("grpclistenaddr", ":50051")
 
 	cfgViper.SetDefault("web.debughost", ":9090")
 	cfgViper.SetDefault("web.shutdowntimeout", 15*time.Second)
@@ -94,7 +92,7 @@ func main() {
 		}
 	}()
 
-	l, err := net.Listen("tcp", DefaultListenAddr)
+	l, err := net.Listen("tcp", cfg.GrpcListenAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -111,6 +109,6 @@ func main() {
 	gs := grpc.NewServer()
 	pb.RegisterTenantServiceServer(gs, tenantSvc)
 
-	log.Println("Serving tenant service on", DefaultListenAddr)
+	log.Println("Serving tenant service on", cfg.GrpcListenAddr)
 	log.Fatal(gs.Serve(l))
 }


### PR DESCRIPTION
# Description

This PR updates a false positive found in the gosec runs.  The tenant service intentionally creates a listener that binds on all network interfaces. This violates gosec rule G102: Bind to all interfaces.  Ordinarily this makes sense because it prevents exposing a network service unintentionally to the world.

We can make this decision explicit by passing in the host:port to this service.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.