### PR TITLE
Remove github-auth-provider from Image Scanner action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -97,11 +97,6 @@ jobs:
         with:
           image-name:  proxy-server
           severity-threshold: HIGH
-      - name: Scan GitHub-Auth Provider
-        uses: Azure/container-scan@v0
-        with:
-          image-name: github-auth-provider
-          severity-threshold: HIGH
       - name: Scan SideCar Proxy
         uses: Azure/container-scan@v0
         with:


### PR DESCRIPTION
# Description

This PR updates the github actions to not check the `github-auth-provider` image.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #47      |

# Checklist:

- [x] I have performed a self-review of my own changes.