### PR TITLE
Removes guest tokens

### DIFF
--- a/cmd/karavictl/cmd/inject_test.go
+++ b/cmd/karavictl/cmd/inject_test.go
@@ -39,10 +39,7 @@ func TestListChange(t *testing.T) {
 	sut := NewListChange(&existing)
 
 	t.Run("injects the proxy pieces", func(t *testing.T) {
-		got, err := injectUsingList(b,
-			"http://image-addr",
-			"http://proxy-addr",
-			"access.jwt.token", "refresh.jwt.token")
+		got, err := injectUsingList(b, "http://image-addr", "http://proxy-addr")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,10 +117,7 @@ func TestListChangeObservability(t *testing.T) {
 	sut := NewListChange(&existing)
 
 	t.Run("injects the proxy pieces", func(t *testing.T) {
-		got, err := injectUsingList(b,
-			"http://image-addr",
-			"http://proxy-addr",
-			"access.jwt.token", "refresh.jwt.token")
+		got, err := injectUsingList(b, "http://image-addr", "http://proxy-addr")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -238,7 +238,7 @@ func run(log *logrus.Entry) error {
 		RolesHandler: web.Adapt(rolesHandler(), web.OtelMW(tp, "roles")),
 		TokenHandler: web.Adapt(refreshTokenHandler(cfg.Web.JWTSigningSecret), web.OtelMW(tp, "refresh")),
 		ProxyHandler: web.Adapt(dh, web.OtelMW(tp, "dispatch")),
-		ClientInstallScriptHandler: web.Adapt(web.ClientInstallHandler(cfg.Web.SidecarProxyAddr, cfg.Web.JWTSigningSecret),
+		ClientInstallScriptHandler: web.Adapt(web.ClientInstallHandler(cfg.Web.SidecarProxyAddr),
 			web.OtelMW(tp, "client-installer")),
 	}
 

--- a/internal/web/client_install_handler.go
+++ b/internal/web/client_install_handler.go
@@ -2,9 +2,7 @@ package web
 
 import (
 	"fmt"
-	"karavi-authorization/internal/token"
 	"net/http"
-	"time"
 )
 
 // DefaultSidecarProxyAddr is the default location where a client can
@@ -21,36 +19,15 @@ kubectl get secrets,deployments,daemonsets -n vxflexos -o yaml \
   | karavictl inject \
   --image-addr %s \
   --proxy-host %s \
-  --guest-access-token %s \
-  --guest-refresh-token %s \
   | kubectl apply -f -
 kubectl rollout status -n vxflexos deploy/vxflexos-controller
 kubectl rollout status -n vxflexos ds/vxflexos-node`
 
-// Guest is used for the Guest tenant and role name.
-const Guest = "Guest"
-
 // ClientInstallHandler returns a handler that will serve up an installer
 // script to requesting clients.
-func ClientInstallHandler(imageAddr, jwtSigningSecret string) http.Handler {
+func ClientInstallHandler(imageAddr string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
-		tp, err := token.Create(token.Config{
-			Tenant:            Guest,
-			Roles:             []string{Guest},
-			JWTSigningSecret:  jwtSigningSecret,
-			AccessExpiration:  24 * time.Hour,
-			RefreshExpiration: 24 * time.Hour,
-		})
-		if err != nil {
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			return
-		}
-
-		fmt.Fprintf(w, InstallScriptFormat,
-			imageAddr,
-			host,
-			tp.Access,
-			tp.Refresh)
+		fmt.Fprintf(w, InstallScriptFormat, imageAddr, host)
 	})
 }

--- a/internal/web/client_install_handler_test.go
+++ b/internal/web/client_install_handler_test.go
@@ -17,11 +17,8 @@ func TestClientInstallHandler(t *testing.T) {
 	wantHost := fmt.Sprintf("--proxy-host %s", r.Host)
 	imageAddr := "10.0.0.1/sidecar:latest"
 	wantImageAddr := fmt.Sprintf("--image-addr %s", imageAddr)
-	// the tokens are based on time, so we can't easily test for them.
-	wantAccessTkn := fmt.Sprintf("--guest-access-token")
-	wantRefreshTkn := fmt.Sprintf("--guest-refresh-token")
 
-	web.ClientInstallHandler(imageAddr, "secret").ServeHTTP(w, r)
+	web.ClientInstallHandler(imageAddr).ServeHTTP(w, r)
 	b, err := ioutil.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -32,11 +29,5 @@ func TestClientInstallHandler(t *testing.T) {
 	}
 	if !bytes.Contains(b, []byte(wantImageAddr)) {
 		t.Error("expected body to contain proxy host")
-	}
-	if !bytes.Contains(b, []byte(wantAccessTkn)) {
-		t.Error("expected body to contain guest access token")
-	}
-	if !bytes.Contains(b, []byte(wantRefreshTkn)) {
-		t.Error("expected body to contain guest refresh token")
 	}
 }


### PR DESCRIPTION
# Description

This PR removes the guest tokens from Karavi Authorization. The original intention for these was to not have to rely on the user to add the token secret first.  This will now become a pre-requisite, but should be less of a problem as we unify Karavi and the CSI Drivers in the future.

Note: this can go in after the TLS changes to avoid merge conflicts.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.