### PR TITLE
Add persistent volume claim for redis-primary

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -154,12 +154,35 @@ spec:
       - name: primary
         image: docker.io/redis:6.0.8-alpine
         imagePullPolicy: IfNotPresent
+        args: ["--appendonly", "yes", "--appendfsync", "always"]
         resources:
           requests:
             cpu: 100m
             memory: 100Mi
         ports:
         - containerPort: 6379
+        volumeMounts:
+          - name: redis-primary-volume
+            mountPath: /data
+      volumes:
+        - name: redis-primary-volume
+          persistentVolumeClaim:
+            claimName: redis-primary-pv-claim
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-primary-pv-claim
+  namespace: karavi
+  labels:
+    app: redis-primary
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 8Gi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -52,6 +52,8 @@ This allows for Karavi Authorization to be installed in network-restricted envir
 
 A Storage Administrator can execute the installer or rpm package as a root user or via `sudo`.
 
+After deployment, application data will be stored on the system under `/var/lib/rancher/k3s/storage/`.
+
 ## Roles and Responsibilities
 
 ### Storage Administrators


### PR DESCRIPTION
# Description

This PR adds a PersistentVolumeClaim to the redis-primary deployment that will persist data in case of node failure or reboot. The PVC uses the `local-path` StorageClass which is backed by Rancher's Local Path Provisioner (https://rancher.com/docs/k3s/latest/en/storage/). By default this provisioner creates persistent volumes on the host under /var/lib/rancher/k3s/storage.

# Testing

1. Created multiple tenants using karavictl.
2. Verified the data was being persisted in file /var/lib/rancher/k3s/storage/pvc-df119be2-2f9d-4b89-8973-52fdc8f01bdb/appendonly.aof
3. Restarted all deployments in Karavi Authorization.
4. Verified the tenants were being listed properly using karavictl.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #56      |

# Checklist:

- [x] I have performed a self-review of my own changes.