### PR TITLE
Bugfix 54 vxflexos provisioner metadata inject

### DIFF
--- a/cmd/karavictl/cmd/inject.go
+++ b/cmd/karavictl/cmd/inject.go
@@ -536,17 +536,19 @@ func (lc *ListChange) injectIntoDeployment(imageAddr, proxyHost string) {
 	deploy.Annotations["com.dell.karavi-authorization-proxy"] = "true"
 
 	// Add the extra-create-metadata flag to provisioner if it does not exist
-	provisionerMetaDataFlag := false
-	for i, c := range deploy.Spec.Template.Spec.Containers {
-		if c.Name == "provisioner" {
-			for _, a := range c.Args {
-				if a == "--extra-create-metadata" {
-					provisionerMetaDataFlag = true
-					break
+	if deploy.Name == "vxflexos-controller" {
+		provisionerMetaDataFlag := false
+		for i, c := range deploy.Spec.Template.Spec.Containers {
+			if c.Name == "provisioner" {
+				for _, a := range c.Args {
+					if a == "--extra-create-metadata" {
+						provisionerMetaDataFlag = true
+						break
+					}
 				}
-			}
-			if !provisionerMetaDataFlag {
-				deploy.Spec.Template.Spec.Containers[i].Args = append(deploy.Spec.Template.Spec.Containers[i].Args, "--extra-create-metadata")
+				if !provisionerMetaDataFlag {
+					deploy.Spec.Template.Spec.Containers[i].Args = append(deploy.Spec.Template.Spec.Containers[i].Args, "--extra-create-metadata")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description
Vxflexos driver provisioner container **must** have the `--extra-create-metadata` flag used in order for the volume name to be passed to the authorization proxy server. This PR ensures that the flag is added if it does not already exist when running `karavictl inject`.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #54      |

# Checklist:

- [x] I have performed a self-review of my own changes.