### PR TITLE
Installer output fixes

### DIFF
--- a/deploy/install.go
+++ b/deploy/install.go
@@ -682,7 +682,7 @@ func (dp *DeployProcess) AddHostName() {
 	}
 
 	if !dp.cfg.IsSet("hostname") {
-		dp.Err = fmt.Errorf("missing hostName configuration")
+		dp.Err = fmt.Errorf("missing hostname configuration")
 		return
 	}
 


### PR DESCRIPTION
# Description

This PR addresses some cleanup of the authorization installer output:
* Prints a message showing the location of the config file used.
* Fix "hostName" -> "hostname" and add a newline at the end of the error message when the hostname is missing.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10|

# Checklist:

- [X] I have performed a self-review of my own changes.