### PR TITLE
Add loop to wait for karavi namespace

### DIFF
--- a/policies/policy-install.sh
+++ b/policies/policy-install.sh
@@ -2,8 +2,10 @@
 set -x
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
 
+K3S=/usr/local/bin/k3s
+
 counter=1
-while [[ $(k3s kubectl get namespaces | grep karavi | wc -l) -ne 1 ]]
+while [[ $($K3S kubectl get namespaces | grep karavi | wc -l) -ne 1 ]]
 do 
     if [[ "$counter" -eq 30 ]]
     then
@@ -16,7 +18,6 @@ do
 done
 
 cd "$(dirname "$0")"
-K3S=/usr/local/bin/k3s
 $K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config
 $K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config
 $K3S kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config


### PR DESCRIPTION
# Description

This PR has the policy-install script wait for the karavi namespace to be available in the k3s deployment before creating resources in that namespace.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #10      |

# Checklist:

- [x] I have performed a self-review of my own changes.