### PR TITLE
Create the storage system secret earlier with default value

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -44,6 +44,14 @@ subjects:
   name: system:serviceaccounts:karavi
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: karavi-storage-secret
+  namespace: karavi
+data:
+  storage-systems.yaml: c3RvcmFnZToK
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -282,11 +290,4 @@ spec:
   - protocol: TCP
     port: 8081
     targetPort: 8081
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: karavi-storage-secret
-  namespace: karavi
-data:
-  storage-systems.yaml:
+


### PR DESCRIPTION
# Description

This PR addresses a timing issue where the storage system K8s secret is not ready before the proxy server comes up.


# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/karavi-authorization/issues/10 |

# Checklist:

- [X] I have performed a self-review of my own changes.