### PR TITLE
No upper bound on quotas created for roles

### DIFF
--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -163,7 +163,7 @@ func validatePowerFlexPool(storageSystemDetails System, storageSystemID string, 
 		return err
 	}
 
-    // Ensuring that the storage pool exists
+	// Ensuring that the storage pool exists
 	_, err = storagePool.GetStatistics()
 	if err != nil {
 		return err

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -163,13 +163,14 @@ func validatePowerFlexPool(storageSystemDetails System, storageSystemID string, 
 		return err
 	}
 
-	storagePoolStatistics, err := storagePool.GetStatistics()
+    // Ensuring that the storage pool exists
+	_, err = storagePool.GetStatistics()
 	if err != nil {
 		return err
 	}
 
-	if int(poolQuota.Quota) > storagePoolStatistics.CapacityAvailableForVolumeAllocationInKb {
-		return errors.New("the specified quota is larger than the storage capacity")
+	if int(poolQuota.Quota) < 0 {
+		return errors.New("the specified quota needs to be a positive number")
 	}
 	return nil
 }

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -109,6 +109,9 @@ func Test_Unit_RoleCreate(t *testing.T) {
 		"success creating role with json file": func(*testing.T) (string, int) {
 			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=9000000", 0
 		},
+		"failure creating role with negative quota": func(*testing.T) (string, int) {
+			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=-2", 1
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Removed upper bound verification of quotas that are specified when creating or updating a role for powerflex.
# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|      #73     |

# Checklist:

- [x] I have performed a self-review of my own changes.