### PR TITLE
karavictl list/get powermax

### DIFF
--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/dell/goscaleio"
@@ -42,6 +43,16 @@ type System struct {
 	Password string `yaml:"password"`
 	Endpoint string `yaml:"endpoint"`
 	Insecure bool   `yaml:"insecure"`
+}
+
+// SystemID wraps a system ID to be a quoted string because system IDs could be all numbers
+// which will cause issues with yaml marshalers
+type SystemID struct {
+	Value string
+}
+
+func (id SystemID) String() string {
+	return fmt.Sprintf("%q", strings.ReplaceAll(id.Value, `"`, ""))
 }
 
 var supportedStorageTypes = map[string]struct{}{
@@ -201,7 +212,7 @@ var storageCreateCmd = &cobra.Command{
 		if pfs == nil {
 			pfs = make(map[string]System)
 		}
-		pfs[input.SystemID] = System{
+		pfs[SystemID{Value: input.SystemID}.String()] = System{
 			User:     input.User,
 			Password: input.Password,
 			Endpoint: input.Endpoint,

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestStorageGetCmd(t *testing.T) {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(
+			context.Background(),
+			os.Args[0],
+			append([]string{
+				"-test.run=TestK3sSubprocessStorageGet",
+				"--",
+				name}, args...)...)
+		cmd.Env = append(os.Environ(), "WANT_GO_TEST_SUBPROCESS=1")
+
+		return cmd
+	}
+	defer func() {
+		execCommandContext = exec.CommandContext
+	}()
+
+	t.Run("get powerflex storage", func(t *testing.T) {
+		setFlag(t, getCmd, "type", "powerflex")
+		setFlag(t, getCmd, "system-id", "542a2d5f5122210f")
+		var out bytes.Buffer
+		getCmd.SetOut(&out)
+		getCmd.Run(getCmd, nil)
+
+		var sys System
+		err := json.Unmarshal(out.Bytes(), &sys)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if &sys == nil {
+			t.Errorf("expected non-nil powerflex system")
+		}
+
+	})
+
+	t.Run("get powermax storage", func(t *testing.T) {
+		setFlag(t, getCmd, "type", "powermax")
+		setFlag(t, getCmd, "system-id", "000197900714")
+		var out bytes.Buffer
+		getCmd.SetOut(&out)
+		getCmd.Run(getCmd, nil)
+
+		var sys System
+		err := json.Unmarshal(out.Bytes(), &sys)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if &sys == nil {
+			t.Errorf("expected non-nil powermax system")
+		}
+	})
+
+	t.Run("no storage type", func(t *testing.T) {
+		setFlag(t, getCmd, "type", "")
+		setFlag(t, getCmd, "system-id", "000197900714")
+		var out bytes.Buffer
+		getCmd.SetErr(&out)
+
+		done := make(chan struct{})
+		wantExitCode := 1
+		var gotExitCode int
+		osExit = func(c int) {
+			gotExitCode = c
+			done <- struct{}{} // allows the test to progress
+			done <- struct{}{} // stop this function returning
+		}
+		defer func() { osExit = os.Exit }()
+
+		go getCmd.Run(getCmd, nil)
+		<-done
+
+		if gotExitCode != wantExitCode {
+			t.Errorf("got exit code %d, want %d", gotExitCode, wantExitCode)
+		}
+		wantToContain := "system type not specified"
+		if !strings.Contains(string(out.Bytes()), wantToContain) {
+			t.Errorf("expected output to contain %q", wantToContain)
+		}
+	})
+
+	t.Run("no storage id", func(t *testing.T) {
+		setFlag(t, getCmd, "type", "powerflex")
+		setFlag(t, getCmd, "system-id", "")
+		var out bytes.Buffer
+		getCmd.SetErr(&out)
+
+		done := make(chan struct{})
+		wantExitCode := 1
+		var gotExitCode int
+		osExit = func(c int) {
+			gotExitCode = c
+			done <- struct{}{} // allows the test to progress
+			done <- struct{}{} // stop this function returning
+		}
+		defer func() { osExit = os.Exit }()
+
+		go getCmd.Run(getCmd, nil)
+		<-done
+
+		if gotExitCode != wantExitCode {
+			t.Errorf("got exit code %d, want %d", gotExitCode, wantExitCode)
+		}
+		wantToContain := "system id not specified"
+		if !strings.Contains(string(out.Bytes()), wantToContain) {
+			t.Errorf("expected output to contain %q", wantToContain)
+		}
+	})
+}
+
+func TestK3sSubprocessStorageGet(t *testing.T) {
+	if v := os.Getenv("WANT_GO_TEST_SUBPROCESS"); v != "1" {
+		t.Skip("not being run as a subprocess")
+	}
+
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = os.Args[i+1:]
+			break
+		}
+	}
+	defer os.Exit(0)
+
+	// k3s kubectl [get,create,apply]
+	switch os.Args[2] {
+	case "get":
+		b, err := ioutil.ReadFile("testdata/kubectl_get_secret_storage_powerflex_powermax.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = io.Copy(os.Stdout, bytes.NewReader(b)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/karavictl/cmd/storage_list.go
+++ b/cmd/karavictl/cmd/storage_list.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,22 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		errAndExit := func(err error) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
+			osExit(1)
+		}
+
+		// Convenience functions for ignoring errors whilst
+		// getting flag values.
+		flagStringValue := func(v string, err error) string {
+			if err != nil {
+				errAndExit(err)
+			}
+			return v
+		}
+
+		storageType := flagStringValue(cmd.Flags().GetString("type"))
 
 		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
@@ -63,10 +80,32 @@ var listCmd = &cobra.Command{
 		if err := yaml.Unmarshal(scrubbed, &m); err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
-		if err := JSONOutput(cmd.OutOrStdout(), &m); err != nil {
+
+		s := filterStorage(storageType, m)
+		if err := JSONOutput(cmd.OutOrStdout(), &s); err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
 	},
+}
+
+func filterStorage(storageType string, allStorage map[string]interface{}) interface{} {
+	if storageType == "" {
+		return allStorage
+	}
+
+	output := make(map[string]interface{})
+	if storage, ok := allStorage["storage"].(map[string]interface{}); ok {
+		for i, v := range storage {
+			if i == storageType {
+				if systems, ok := v.(map[string]interface{}); ok {
+					for id, system := range systems {
+						output[id] = system
+					}
+				}
+			}
+		}
+	}
+	return output
 }
 
 func scrubPasswords(b []byte) ([]byte, error) {
@@ -99,4 +138,6 @@ func scrubPasswordsRecurse(o interface{}) {
 
 func init() {
 	storageCmd.AddCommand(listCmd)
+
+	listCmd.Flags().StringP("type", "t", "", "Type of storage system")
 }

--- a/cmd/karavictl/cmd/storage_list.go
+++ b/cmd/karavictl/cmd/storage_list.go
@@ -96,11 +96,12 @@ func filterStorage(storageType string, allStorage map[string]interface{}) interf
 	output := make(map[string]interface{})
 	if storage, ok := allStorage["storage"].(map[string]interface{}); ok {
 		for i, v := range storage {
-			if i == storageType {
-				if systems, ok := v.(map[string]interface{}); ok {
-					for id, system := range systems {
-						output[id] = system
-					}
+			if i != storageType {
+				continue
+			}
+			if systems, ok := v.(map[string]interface{}); ok {
+				for id, system := range systems {
+					output[id] = system
 				}
 			}
 		}

--- a/cmd/karavictl/cmd/storage_list.go
+++ b/cmd/karavictl/cmd/storage_list.go
@@ -25,6 +25,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var (
+	jsonOpt = func(d *json.Decoder) *json.Decoder {
+		d.UseNumber()
+		return d
+	}
+)
+
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -70,14 +77,13 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
-
 		scrubbed, err := scrubPasswords(decodedSystems)
 		if err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
 
 		m := make(map[string]interface{})
-		if err := yaml.Unmarshal(scrubbed, &m); err != nil {
+		if err := yaml.Unmarshal(scrubbed, &m, yaml.JSONOpt(jsonOpt)); err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
 
@@ -111,7 +117,7 @@ func filterStorage(storageType string, allStorage map[string]interface{}) interf
 
 func scrubPasswords(b []byte) ([]byte, error) {
 	m := make(map[string]interface{})
-	err := yaml.Unmarshal(b, &m)
+	err := yaml.Unmarshal(b, &m, yaml.JSONOpt(jsonOpt))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/karavictl/cmd/storage_list.go
+++ b/cmd/karavictl/cmd/storage_list.go
@@ -25,13 +25,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var (
-	jsonOpt = func(d *json.Decoder) *json.Decoder {
-		d.UseNumber()
-		return d
-	}
-)
-
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -83,7 +76,7 @@ var listCmd = &cobra.Command{
 		}
 
 		m := make(map[string]interface{})
-		if err := yaml.Unmarshal(scrubbed, &m, yaml.JSONOpt(jsonOpt)); err != nil {
+		if err := yaml.Unmarshal(scrubbed, &m); err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
 
@@ -117,7 +110,7 @@ func filterStorage(storageType string, allStorage map[string]interface{}) interf
 
 func scrubPasswords(b []byte) ([]byte, error) {
 	m := make(map[string]interface{})
-	err := yaml.Unmarshal(b, &m, yaml.JSONOpt(jsonOpt))
+	err := yaml.Unmarshal(b, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestStorageListCmd(t *testing.T) {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(
+			context.Background(),
+			os.Args[0],
+			append([]string{
+				"-test.run=TestK3sSubprocessStorageList",
+				"--",
+				name}, args...)...)
+		cmd.Env = append(os.Environ(), "WANT_GO_TEST_SUBPROCESS=1")
+
+		return cmd
+	}
+	defer func() {
+		execCommandContext = exec.CommandContext
+	}()
+
+	t.Run("list all storage", func(t *testing.T) {
+		setFlag(t, listCmd, "type", "")
+		listCmd.Run(listCmd, nil)
+	})
+
+	t.Run("list powerflex storage", func(t *testing.T) {
+		setFlag(t, listCmd, "type", "powerflex")
+		var out bytes.Buffer
+		listCmd.SetOut(&out)
+		listCmd.Run(listCmd, nil)
+
+		var sysType SystemType
+		err := json.Unmarshal(out.Bytes(), &sysType)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(sysType) != 1 {
+			t.Errorf("expected one storage response, got %d", len(sysType))
+		}
+
+		if _, ok := sysType["542a2d5f5122210f"]; !ok {
+			t.Errorf("expected powerflex id 542a2d5f5122210f, id does not exist")
+		}
+	})
+
+	t.Run("list powermax storage", func(t *testing.T) {
+		setFlag(t, listCmd, "type", "powermax")
+		var out bytes.Buffer
+		listCmd.SetOut(&out)
+		listCmd.Run(listCmd, nil)
+
+		var sysType SystemType
+		err := json.Unmarshal(out.Bytes(), &sysType)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(sysType) != 1 {
+			t.Errorf("expected one storage response, got %d", len(sysType))
+		}
+
+		if _, ok := sysType["000197900714"]; !ok {
+			t.Errorf("expected powerflex id 000197900714, id does not exist")
+		}
+	})
+}
+
+func TestK3sSubprocessStorageList(t *testing.T) {
+	if v := os.Getenv("WANT_GO_TEST_SUBPROCESS"); v != "1" {
+		t.Skip("not being run as a subprocess")
+	}
+
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = os.Args[i+1:]
+			break
+		}
+	}
+	defer os.Exit(0)
+
+	// k3s kubectl [get,create,apply]
+	switch os.Args[2] {
+	case "get":
+		b, err := ioutil.ReadFile("testdata/kubectl_get_secret_storage_powerflex_powermax.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = io.Copy(os.Stdout, bytes.NewReader(b)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/karavictl/cmd/testdata/kubectl_get_secret_storage_powerflex_powermax.json
+++ b/cmd/karavictl/cmd/testdata/kubectl_get_secret_storage_powerflex_powermax.json
@@ -1,12 +1,12 @@
 {
     "apiVersion": "v1",
     "data": {
-        "storage-systems.yaml": "c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICA1NDJhMmQ1ZjUxMjIyMTBmOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4="
+        "storage-systems.yaml": "c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICAiNTQyYTJkNWY1MTIyMjEwZiI6CiAgICAgIEVuZHBvaW50OiBodHRwczovL2xvY2FsaG9zdAogICAgICBJbnNlY3VyZTogdHJ1ZQogICAgICBQYXNzOiBQYXNzd29yZDEyMwogICAgICBVc2VyOiBhZG1pbg=="
     },
     "kind": "Secret",
     "metadata": {
         "annotations": {
-            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"storage-systems.yaml\":\"c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICA1NDJhMmQ1ZjUxMjIyMTBmOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4=\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"name\":\"karavi-storage-secret\",\"namespace\":\"karavi\"}}\n",
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"storage-systems.yaml\":\"c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICAiNTQyYTJkNWY1MTIyMjEwZiI6CiAgICAgIEVuZHBvaW50OiBodHRwczovL2xvY2FsaG9zdAogICAgICBJbnNlY3VyZTogdHJ1ZQogICAgICBQYXNzOiBQYXNzd29yZDEyMwogICAgICBVc2VyOiBhZG1pbg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"name\":\"karavi-storage-secret\",\"namespace\":\"karavi\"}}\n",
             "objectset.rio.cattle.io/applied": "{\"apiVersion\":\"v1\",\"data\":{\"storage-systems.yaml\":null},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"objectset.rio.cattle.io/id\":\"\",\"objectset.rio.cattle.io/owner-gvk\":\"k3s.cattle.io/v1, Kind=Addon\",\"objectset.rio.cattle.io/owner-name\":\"deployment\",\"objectset.rio.cattle.io/owner-namespace\":\"kube-system\"},\"labels\":{\"objectset.rio.cattle.io/hash\":\"93b4ed0aaef6b76eb1853ab69f3fbc03e3a63c51\"},\"name\":\"karavi-storage-secret\",\"namespace\":\"karavi\"}}",
             "objectset.rio.cattle.io/id": "",
             "objectset.rio.cattle.io/owner-gvk": "k3s.cattle.io/v1, Kind=Addon",

--- a/cmd/karavictl/cmd/testdata/kubectl_get_secret_storage_powerflex_powermax.json
+++ b/cmd/karavictl/cmd/testdata/kubectl_get_secret_storage_powerflex_powermax.json
@@ -1,0 +1,71 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "storage-systems.yaml": "c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICA1NDJhMmQ1ZjUxMjIyMTBmOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"storage-systems.yaml\":\"c3RvcmFnZToKICBwb3dlcm1heDoKICAgICIwMDAxOTc5MDA3MTQiOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4KICBwb3dlcmZsZXg6CiAgICA1NDJhMmQ1ZjUxMjIyMTBmOgogICAgICBFbmRwb2ludDogaHR0cHM6Ly9sb2NhbGhvc3QKICAgICAgSW5zZWN1cmU6IHRydWUKICAgICAgUGFzczogUGFzc3dvcmQxMjMKICAgICAgVXNlcjogYWRtaW4=\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"name\":\"karavi-storage-secret\",\"namespace\":\"karavi\"}}\n",
+            "objectset.rio.cattle.io/applied": "{\"apiVersion\":\"v1\",\"data\":{\"storage-systems.yaml\":null},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"objectset.rio.cattle.io/id\":\"\",\"objectset.rio.cattle.io/owner-gvk\":\"k3s.cattle.io/v1, Kind=Addon\",\"objectset.rio.cattle.io/owner-name\":\"deployment\",\"objectset.rio.cattle.io/owner-namespace\":\"kube-system\"},\"labels\":{\"objectset.rio.cattle.io/hash\":\"93b4ed0aaef6b76eb1853ab69f3fbc03e3a63c51\"},\"name\":\"karavi-storage-secret\",\"namespace\":\"karavi\"}}",
+            "objectset.rio.cattle.io/id": "",
+            "objectset.rio.cattle.io/owner-gvk": "k3s.cattle.io/v1, Kind=Addon",
+            "objectset.rio.cattle.io/owner-name": "deployment",
+            "objectset.rio.cattle.io/owner-namespace": "kube-system"
+        },
+        "creationTimestamp": "2021-02-18T05:17:28Z",
+        "labels": {
+            "objectset.rio.cattle.io/hash": "93b4ed0aaef6b76eb1853ab69f3fbc03e3a63c51"
+        },
+        "managedFields": [
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:data": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:objectset.rio.cattle.io/applied": {},
+                            "f:objectset.rio.cattle.io/id": {},
+                            "f:objectset.rio.cattle.io/owner-gvk": {},
+                            "f:objectset.rio.cattle.io/owner-name": {},
+                            "f:objectset.rio.cattle.io/owner-namespace": {}
+                        },
+                        "f:labels": {
+                            ".": {},
+                            "f:objectset.rio.cattle.io/hash": {}
+                        }
+                    },
+                    "f:type": {}
+                },
+                "manager": "k3s",
+                "operation": "Update",
+                "time": "2021-02-18T05:17:28Z"
+            },
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:data": {
+                        "f:storage-systems.yaml": {}
+                    },
+                    "f:metadata": {
+                        "f:annotations": {
+                            "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                        }
+                    }
+                },
+                "manager": "kubectl",
+                "operation": "Update",
+                "time": "2021-02-18T06:49:01Z"
+            }
+        ],
+        "name": "karavi-storage-secret",
+        "namespace": "karavi",
+        "resourceVersion": "4655",
+        "selfLink": "/api/v1/namespaces/karavi/secrets/karavi-storage-secret",
+        "uid": "d37a5e36-45e1-4bbe-95f4-a4dcd8c00e13"
+    },
+    "type": "Opaque"
+}


### PR DESCRIPTION
# Description

This PR adds support for listing/getting PowerMax arrays, filtering the `storage list` output by storage type, and enforcing arguments when getting storage.

**List all storage:**
`karavictl storage list`

**List powerflex storage:**
`karavictl storage list --type powerflex`

**List powermax storage:**
`karavictl storage list --type powermax`

The `karavictl storage get` command now does not default to powerflex. You must supply a storage type and system-id. Otherwise, you will see errors such as `error: system type not specified` and `error: system type not specified`.

There is a new secret in cmd/karavictl/cmd/testdata called `kubectl_get_secret_storage_powerflex_powermax.json` with the following secret data in `storage-systems.yaml`. The system IDs are quoted because otherwise a numeric ID will could be in scientific notation in the JSON output.

```
storage:
  powermax:
    "000197900714":
      Endpoint: https://localhost
      Insecure: true
      Pass: Password123
      User: admin
  powerflex:
    "542a2d5f5122210f":
      Endpoint: https://localhost
      Insecure: true
      Pass: Password123
      User: admin
```

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #72      |

# Checklist:

- [x] I have performed a self-review of my own changes.
```
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  4.301s  coverage: 57.6% of statements
ok      karavi-authorization/cmd/proxy-server   0.067s  coverage: 0.7% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
?       karavi-authorization/cmd/tenant-service [no test files]
ok      karavi-authorization/deploy     0.095s  coverage: 84.6% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.091s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     6.607s  coverage: 68.0% of statements
ok      karavi-authorization/internal/quota     0.369s  coverage: 92.6% of statements
ok      karavi-authorization/internal/roles     0.048s  coverage: 96.0% of statements
ok      karavi-authorization/internal/tenantsvc 1.805s  coverage: 82.9% of statements
ok      karavi-authorization/internal/token     0.041s  coverage: 90.0% of statements
ok      karavi-authorization/internal/web       0.047s  coverage: 24.1% of statements
?       karavi-authorization/pb [no test files]
```