### PR TITLE
karavictl validations for input flags when creating and updating resources

### DIFF
--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -47,6 +47,9 @@ var roleCreateCmd = &cobra.Command{
 		var rff roles.JSON
 		for _, v := range roleFlags {
 			t := strings.Split(v, "=")
+			if len(t) < 5 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("role does not have enough arguments")))
+			}
 			err = rff.Add(roles.NewInstance(t[0], t[1:]...))
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
@@ -93,7 +96,6 @@ var roleCreateCmd = &cobra.Command{
 
 func init() {
 	roleCmd.AddCommand(roleCreateCmd)
-	roleCreateCmd.Flags().StringP("from-file", "f", "", "role data from a file")
 	roleCreateCmd.Flags().StringSlice("role", []string{}, "role in the form <name>=<type>=<id>=<pool>=<quota>")
 }
 

--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const roleFlagSize = 5
+
 // roleCreateCmd represents the role command
 var roleCreateCmd = &cobra.Command{
 	Use:   "create",
@@ -47,7 +49,7 @@ var roleCreateCmd = &cobra.Command{
 		var rff roles.JSON
 		for _, v := range roleFlags {
 			t := strings.Split(v, "=")
-			if len(t) < 5 {
+			if len(t) < roleFlagSize {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("role does not have enough arguments")))
 			}
 			err = rff.Add(roles.NewInstance(t[0], t[1:]...))

--- a/cmd/karavictl/cmd/rolebinding_create.go
+++ b/cmd/karavictl/cmd/rolebinding_create.go
@@ -16,7 +16,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"karavi-authorization/pb"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -37,12 +39,6 @@ var createRoleBindingCmd = &cobra.Command{
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
-
 		tenant, err := cmd.Flags().GetString("tenant")
 		if err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
@@ -51,6 +47,19 @@ var createRoleBindingCmd = &cobra.Command{
 		if err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 		}
+
+		if strings.TrimSpace(tenant) == "" {
+			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no tenant input provided"))
+		}
+		if strings.TrimSpace(role) == "" {
+			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no role input provided"))
+		}
+
+		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+		if err != nil {
+			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+		}
+		defer conn.Close()
 
 		_, err = tenantClient.BindRole(context.Background(), &pb.BindRoleRequest{
 			TenantName: tenant,

--- a/cmd/karavictl/cmd/rolebinding_create.go
+++ b/cmd/karavictl/cmd/rolebinding_create.go
@@ -17,10 +17,9 @@ package cmd
 import (
 	"context"
 	"errors"
+	"github.com/spf13/cobra"
 	"karavi-authorization/pb"
 	"strings"
-
-	"github.com/spf13/cobra"
 )
 
 // createRoleBindingCmd represents the rolebinding command
@@ -51,6 +50,7 @@ var createRoleBindingCmd = &cobra.Command{
 		if strings.TrimSpace(tenant) == "" {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no tenant input provided"))
 		}
+
 		if strings.TrimSpace(role) == "" {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no role input provided"))
 		}
@@ -75,5 +75,13 @@ func init() {
 	rolebindingCmd.AddCommand(createRoleBindingCmd)
 
 	createRoleBindingCmd.Flags().StringP("tenant", "t", "", "Tenant name")
+	err := createRoleBindingCmd.MarkFlagRequired("tenant")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, createRoleBindingCmd.ErrOrStderr(), err)
+	}
 	createRoleBindingCmd.Flags().StringP("role", "r", "", "Role name")
+	err = createRoleBindingCmd.MarkFlagRequired("role")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, createRoleBindingCmd.ErrOrStderr(), err)
+	}
 }

--- a/cmd/karavictl/cmd/rolebinding_create_test.go
+++ b/cmd/karavictl/cmd/rolebinding_create_test.go
@@ -19,13 +19,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"google.golang.org/grpc"
 	"io"
 	"io/ioutil"
 	"karavi-authorization/pb"
 	"os"
 	"testing"
-
-	"google.golang.org/grpc"
 )
 
 func TestRolebindingCreate(t *testing.T) {
@@ -49,7 +48,7 @@ func TestRolebindingCreate(t *testing.T) {
 		var gotOutput bytes.Buffer
 
 		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create"})
+		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
 		rootCmd.Execute()
 
 		if !gotCalled {
@@ -71,7 +70,7 @@ func TestRolebindingCreate(t *testing.T) {
 		var gotOutput bytes.Buffer
 
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create"})
+		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
 		go rootCmd.Execute()
 		<-done
 
@@ -107,7 +106,7 @@ func TestRolebindingCreate(t *testing.T) {
 		var gotOutput bytes.Buffer
 
 		createRoleBindingCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create"})
+		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -77,10 +77,10 @@ var storageCreateCmd = &cobra.Command{
 			}
 			return v
 		}
-		verifyInput := func(Type string) string {
-			inputText := flagStringValue(cmd.Flags().GetString(Type))
+		verifyInput := func(v string) string {
+			inputText := flagStringValue(cmd.Flags().GetString(v))
 			if strings.TrimSpace(inputText) == "" {
-				errAndExit(fmt.Errorf("no input provided: %s", Type))
+				errAndExit(fmt.Errorf("no input provided: %s", v))
 			}
 			return inputText
 		}

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -258,9 +258,25 @@ func init() {
 	storageCmd.AddCommand(storageCreateCmd)
 
 	storageCreateCmd.Flags().StringP("type", "t", "", "Type of storage system")
+	err := storageCreateCmd.MarkFlagRequired("type")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCreateCmd.ErrOrStderr(), err)
+	}
 	storageCreateCmd.Flags().StringP("endpoint", "e", "", "Endpoint of REST API gateway")
+	err = storageCreateCmd.MarkFlagRequired("endpoint")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCreateCmd.ErrOrStderr(), err)
+	}
 	storageCreateCmd.Flags().StringP("system-id", "s", "", "System identifier")
+	err = storageCreateCmd.MarkFlagRequired("system-id")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCreateCmd.ErrOrStderr(), err)
+	}
 	storageCreateCmd.Flags().StringP("user", "u", "", "Username")
+	err = storageCreateCmd.MarkFlagRequired("user")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCreateCmd.ErrOrStderr(), err)
+	}
 	storageCreateCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	storageCreateCmd.Flags().BoolP("insecure", "i", false, "Insecure skip verify")
 }

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/dell/goscaleio"
@@ -76,6 +77,13 @@ var storageCreateCmd = &cobra.Command{
 			}
 			return v
 		}
+		verifyInput := func(Type string) string {
+			inputText := flagStringValue(cmd.Flags().GetString(Type))
+			if strings.TrimSpace(inputText) == "" {
+				errAndExit(fmt.Errorf("no input provided: %s", Type))
+			}
+			return inputText
+		}
 
 		// Gather the inputs
 		var input = struct {
@@ -86,10 +94,10 @@ var storageCreateCmd = &cobra.Command{
 			Password string
 			Insecure bool
 		}{
-			Type:     flagStringValue(cmd.Flags().GetString("type")),
-			Endpoint: flagStringValue(cmd.Flags().GetString("endpoint")),
-			SystemID: flagStringValue(cmd.Flags().GetString("system-id")),
-			User:     flagStringValue(cmd.Flags().GetString("user")),
+			Type:     verifyInput("type"),
+			Endpoint: verifyInput("endpoint"),
+			SystemID: verifyInput("system-id"),
+			User:     verifyInput("user"),
 			Password: flagStringValue(cmd.Flags().GetString("password")),
 			Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
 		}
@@ -249,10 +257,10 @@ var storageCreateCmd = &cobra.Command{
 func init() {
 	storageCmd.AddCommand(storageCreateCmd)
 
-	storageCreateCmd.Flags().StringP("type", "t", "powerflex", "Type of storage system")
-	storageCreateCmd.Flags().StringP("endpoint", "e", "https://10.0.0.1", "Endpoint of REST API gateway")
-	storageCreateCmd.Flags().StringP("system-id", "s", "systemid", "System identifier")
-	storageCreateCmd.Flags().StringP("user", "u", "admin", "Username")
+	storageCreateCmd.Flags().StringP("type", "t", "", "Type of storage system")
+	storageCreateCmd.Flags().StringP("endpoint", "e", "", "Endpoint of REST API gateway")
+	storageCreateCmd.Flags().StringP("system-id", "s", "", "System identifier")
+	storageCreateCmd.Flags().StringP("user", "u", "", "Username")
 	storageCreateCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	storageCreateCmd.Flags().BoolP("insecure", "i", false, "Insecure skip verify")
 }

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -57,10 +57,10 @@ var storageUpdateCmd = &cobra.Command{
 			}
 			return v
 		}
-		verifyInput := func(Type string) string {
-			inputText := flagStringValue(cmd.Flags().GetString(Type))
+		verifyInput := func(v string) string {
+			inputText := flagStringValue(cmd.Flags().GetString(v))
 			if strings.TrimSpace(inputText) == "" {
-				errAndExit(fmt.Errorf("no input provided: %s", Type))
+				errAndExit(fmt.Errorf("no input provided: %s", v))
 			}
 			return inputText
 		}

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -201,9 +201,25 @@ func init() {
 	storageCmd.AddCommand(storageUpdateCmd)
 
 	storageUpdateCmd.Flags().StringP("type", "t", "", "Type of storage system")
+	err := storageUpdateCmd.MarkFlagRequired("type")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageUpdateCmd.ErrOrStderr(), err)
+	}
 	storageUpdateCmd.Flags().StringP("endpoint", "e", "", "Endpoint of REST API gateway")
+	err = storageUpdateCmd.MarkFlagRequired("endpoint")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageUpdateCmd.ErrOrStderr(), err)
+	}
 	storageUpdateCmd.Flags().StringP("system-id", "s", "", "System identifier")
+	err = storageUpdateCmd.MarkFlagRequired("system-id")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageUpdateCmd.ErrOrStderr(), err)
+	}
 	storageUpdateCmd.Flags().StringP("user", "u", "", "Username")
+	err = storageUpdateCmd.MarkFlagRequired("user")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageUpdateCmd.ErrOrStderr(), err)
+	}
 	storageUpdateCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	storageUpdateCmd.Flags().BoolP("insecure", "i", false, "Insecure skip verify")
 }

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -157,7 +157,7 @@ var storageUpdateCmd = &cobra.Command{
 			break
 		}
 		if !didUpdate {
-			errAndExit(fmt.Errorf("no matching storage systems to update\n"))
+			errAndExit(fmt.Errorf("no matching storage systems to update"))
 		}
 
 		listData["storage"] = storage

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -20,8 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -37,19 +38,31 @@ var storageUpdateCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		errAndExit := func(err error) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
+			osExit(1)
+		}
+
 		// Convenience functions for ignoring errors whilst
 		// getting flag values.
 		flagStringValue := func(v string, err error) string {
 			if err != nil {
-				log.Fatal(err)
+				errAndExit(err)
 			}
 			return v
 		}
 		flagBoolValue := func(v bool, err error) bool {
 			if err != nil {
-				log.Fatal(err)
+				errAndExit(err)
 			}
 			return v
+		}
+		verifyInput := func(Type string) string {
+			inputText := flagStringValue(cmd.Flags().GetString(Type))
+			if strings.TrimSpace(inputText) == "" {
+				errAndExit(fmt.Errorf("no input provided: %s", Type))
+			}
+			return inputText
 		}
 
 		// Gather the inputs
@@ -61,15 +74,37 @@ var storageUpdateCmd = &cobra.Command{
 			Password string
 			Insecure bool
 		}{
-			Type:     flagStringValue(cmd.Flags().GetString("type")),
-			Endpoint: flagStringValue(cmd.Flags().GetString("endpoint")),
-			SystemID: flagStringValue(cmd.Flags().GetString("system-id")),
-			User:     flagStringValue(cmd.Flags().GetString("user")),
+			Type:     verifyInput("type"),
+			Endpoint: verifyInput("endpoint"),
+			SystemID: verifyInput("system-id"),
+			User:     verifyInput("user"),
 			Password: flagStringValue(cmd.Flags().GetString("password")),
 			Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
 		}
 
-		// TODO(ian): Check for password-stdin
+		// Parse the URL and prepare for a password prompt.
+		urlWithUser, err := url.Parse(input.Endpoint)
+		if err != nil {
+			errAndExit(err)
+		}
+
+		urlWithUser.Scheme = "https"
+		urlWithUser.User = url.User(input.User)
+
+		// If the password was not provided...
+		prompt := fmt.Sprintf("Enter password for %v: ", urlWithUser)
+		// If the password was not provided...
+		if pf := cmd.Flags().Lookup("password"); !pf.Changed {
+			// Get password from stdin
+			readPassword(cmd.ErrOrStderr(), prompt, &input.Password)
+		}
+
+		// Sanitize the endpoint
+		epURL, err := url.Parse(input.Endpoint)
+		if err != nil {
+			errAndExit(err)
+		}
+		epURL.Scheme = "https"
 
 		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
 			"--namespace=karavi",
@@ -78,23 +113,23 @@ var storageUpdateCmd = &cobra.Command{
 
 		b, err := k3sCmd.Output()
 		if err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 
 		base64Systems := struct {
 			Data map[string]string
 		}{}
 		if err := json.Unmarshal(b, &base64Systems); err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 		decodedSystems, err := base64.StdEncoding.DecodeString(base64Systems.Data["storage-systems.yaml"])
 		if err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 
 		var listData map[string]Storage
 		if err := yaml.Unmarshal(decodedSystems, &listData); err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 		if listData == nil || listData["storage"] == nil {
 			listData = make(map[string]Storage)
@@ -122,19 +157,18 @@ var storageUpdateCmd = &cobra.Command{
 			break
 		}
 		if !didUpdate {
-			fmt.Fprintf(os.Stderr, "no matching storage systems to update\n")
-			os.Exit(1)
+			errAndExit(fmt.Errorf("no matching storage systems to update\n"))
 		}
 
 		listData["storage"] = storage
 		b, err = yaml.Marshal(&listData)
 		if err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 
 		tmpFile, err := ioutil.TempFile("", "karavi")
 		if err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 		defer func() {
 			if err := tmpFile.Close(); err != nil {
@@ -146,7 +180,7 @@ var storageUpdateCmd = &cobra.Command{
 		}()
 		_, err = tmpFile.WriteString(string(b))
 		if err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 
 		crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
@@ -158,7 +192,7 @@ var storageUpdateCmd = &cobra.Command{
 		appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
 
 		if err := pipeCommands(crtCmd, appCmd); err != nil {
-			log.Fatal(err)
+			errAndExit(err)
 		}
 	},
 }
@@ -166,10 +200,10 @@ var storageUpdateCmd = &cobra.Command{
 func init() {
 	storageCmd.AddCommand(storageUpdateCmd)
 
-	storageUpdateCmd.Flags().StringP("type", "t", "powerflex", "Type of storage system")
-	storageUpdateCmd.Flags().StringP("endpoint", "e", "https://10.0.0.1", "Endpoint of REST API gateway")
-	storageUpdateCmd.Flags().StringP("system-id", "s", "systemid", "System identifier")
-	storageUpdateCmd.Flags().StringP("user", "u", "admin", "Username")
-	storageUpdateCmd.Flags().StringP("password", "p", "****", "Password")
+	storageUpdateCmd.Flags().StringP("type", "t", "", "Type of storage system")
+	storageUpdateCmd.Flags().StringP("endpoint", "e", "", "Endpoint of REST API gateway")
+	storageUpdateCmd.Flags().StringP("system-id", "s", "", "System identifier")
+	storageUpdateCmd.Flags().StringP("user", "u", "", "Username")
+	storageUpdateCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	storageUpdateCmd.Flags().BoolP("insecure", "i", false, "Insecure skip verify")
 }


### PR DESCRIPTION
# Description

This PR updates all create/update commands for tenant/role/rolebinding/storage to check for valid, non-empty inputs and display appropriate error messages if input is not valid.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
| #78 |

# Checklist:

- [x] I have performed a self-review of my own changes.