### PR TITLE
Support adding roles for PowerMax

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,3 @@
+general:
+  vulnerabilities:
+    - CVE-2020-26160

--- a/cmd/karavictl/cmd/cluster_info.go
+++ b/cmd/karavictl/cmd/cluster_info.go
@@ -22,32 +22,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// clusterInfoCmd represents the clusterInfo command
-var clusterInfoCmd = &cobra.Command{
-	Use:   "cluster-info",
-	Short: "Display the state of resources within the cluster",
-	Long:  `Prints table of resources within the cluster, including their readiness`,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmdArgs := []string{"kubectl", "get", "deploy", "-n", "karavi"}
-		if v, _ := cmd.Flags().GetBool("watch"); v {
-			cmdArgs = append(cmdArgs, "--watch")
-		}
-		kCmd := exec.Command(K3sPath, cmdArgs...)
-		kCmd.Stdout = os.Stdout
-		err := kCmd.Start()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
-		}
+// NewClusterInfoCmd creates a new clusterInfo command
+func NewClusterInfoCmd() *cobra.Command {
+	clusterInfoCmd := &cobra.Command{
+		Use:   "cluster-info",
+		Short: "Display the state of resources within the cluster",
+		Long:  `Prints table of resources within the cluster, including their readiness`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdArgs := []string{"kubectl", "get", "deploy", "-n", "karavi"}
+			if v, _ := cmd.Flags().GetBool("watch"); v {
+				cmdArgs = append(cmdArgs, "--watch")
+			}
+			kCmd := exec.Command(K3sPath, cmdArgs...)
+			kCmd.Stdout = os.Stdout
+			err := kCmd.Start()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
 
-		if err := kCmd.Wait(); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
-		}
-	},
-}
+			if err := kCmd.Wait(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(clusterInfoCmd)
 	clusterInfoCmd.Flags().BoolP("watch", "w", false, "Watch for changes")
+	return clusterInfoCmd
 }

--- a/cmd/karavictl/cmd/generate.go
+++ b/cmd/karavictl/cmd/generate.go
@@ -20,20 +20,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// generateCmd represents the generate command
-var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate resources for use with Karavi",
-	Long:  `Generates resources for use with Karavi`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := cmd.Usage()
-		if err != nil {
-			reportErrorAndExit(JSONOutput, os.Stderr, err)
-		}
-		os.Exit(1)
-	},
-}
+// NewGenerateCmd creates a new generate command
+func NewGenerateCmd() *cobra.Command {
+	generateCmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate resources for use with Karavi",
+		Long:  `Generates resources for use with Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Usage()
+			if err != nil {
+				reportErrorAndExit(JSONOutput, os.Stderr, err)
+			}
+			os.Exit(1)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(generateCmd)
+	return generateCmd
 }

--- a/cmd/karavictl/cmd/generate.go
+++ b/cmd/karavictl/cmd/generate.go
@@ -35,5 +35,6 @@ func NewGenerateCmd() *cobra.Command {
 		},
 	}
 
+	generateCmd.AddCommand(NewGenerateTokenCmd())
 	return generateCmd
 }

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -43,21 +43,20 @@ type Role struct {
 	PoolQuotas      []PoolQuota `json:"pool_quotas"`
 }
 
-// roleCmd represents the role command
-var roleCmd = &cobra.Command{
-	Use:   "role",
-	Short: "Manage roles",
-	Long:  `Manage roles`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Usage(); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("error: %+v", err))
-		}
-		os.Exit(1)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(roleCmd)
+// NewRoleCmd creates a new role command
+func NewRoleCmd() *cobra.Command {
+	roleCmd := &cobra.Command{
+		Use:   "role",
+		Short: "Manage roles",
+		Long:  `Manage roles`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Usage(); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("error: %+v", err))
+			}
+			os.Exit(1)
+		},
+	}
+	return roleCmd
 }
 
 // GetAuthorizedStorageSystems returns list of storage systems added to authorization

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -56,6 +56,12 @@ func NewRoleCmd() *cobra.Command {
 			os.Exit(1)
 		},
 	}
+
+	roleCmd.AddCommand(NewRoleCreateCmd())
+	roleCmd.AddCommand(NewRoleDeleteCmd())
+	roleCmd.AddCommand(NewRoleGetCmd())
+	roleCmd.AddCommand(NewRoleListCmd())
+	roleCmd.AddCommand(NewRoleUpdateCmd())
 	return roleCmd
 }
 

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -137,6 +137,7 @@ var GetPowerFlexEndpoint = func(storageSystemDetails System) string {
 	return storageSystemDetails.Endpoint
 }
 
+// GetPowerMaxEndpoint returns the endpoint URL for a PowerMax system
 var GetPowerMaxEndpoint = func(storageSystemDetails System) string {
 	return storageSystemDetails.Endpoint
 }
@@ -189,7 +190,7 @@ func validatePowerMaxStorageResourcePool(storageSystemDetails System, storageSys
 
 	epURL.Scheme = "https"
 	//TODO(aaron): how should the version (90, 91) be determined?
-	powerMaxClient, err := pmax.NewClientWithArgs(epURL.String(), "91", "", true, false)
+	powerMaxClient, err := pmax.NewClientWithArgs(epURL.String(), "", "", true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"karavi-authorization/internal/roles"
+	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -59,6 +60,7 @@ var roleCreateCmd = &cobra.Command{
 		}
 
 		existingRoles, err := GetRoles()
+		log.Printf("EXISTING_ROLES: %+v", existingRoles)
 		if err != nil {
 			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 		}

--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"karavi-authorization/internal/roles"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,77 +29,76 @@ import (
 
 const roleFlagSize = 5
 
-// roleCreateCmd represents the role command
-var roleCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create one or more Karavi roles",
-	Long:  `Creates one or more Karavi roles`,
-	Run: func(cmd *cobra.Command, args []string) {
-		outFormat := "failed to create role: %+v\n"
+// NewRoleCreateCmd creates a new role command
+func NewRoleCreateCmd() *cobra.Command {
+	roleCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create one or more Karavi roles",
+		Long:  `Creates one or more Karavi roles`,
+		Run: func(cmd *cobra.Command, args []string) {
+			outFormat := "failed to create role: %+v\n"
 
-		roleFlags, err := cmd.Flags().GetStringSlice("role")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
-		}
-
-		if len(roleFlags) == 0 {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("no input")))
-		}
-
-		var rff roles.JSON
-		for _, v := range roleFlags {
-			t := strings.Split(v, "=")
-			if len(t) < roleFlagSize {
-				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("role does not have enough arguments")))
-			}
-			err = rff.Add(roles.NewInstance(t[0], t[1:]...))
+			roleFlags, err := cmd.Flags().GetStringSlice("role")
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 			}
-		}
 
-		existingRoles, err := GetRoles()
-		log.Printf("EXISTING_ROLES: %+v", existingRoles)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
-		}
+			if len(roleFlags) == 0 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("no input")))
+			}
 
-		adding := rff.Instances()
-		var dups []string
-		for _, role := range adding {
-			if existingRoles.Get(role.RoleKey) != nil {
-				var dup bool
-				if dup {
-					dups = append(dups, role.Name)
+			var rff roles.JSON
+			for _, v := range roleFlags {
+				t := strings.Split(v, "=")
+				if len(t) < roleFlagSize {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("role does not have enough arguments")))
+				}
+				err = rff.Add(roles.NewInstance(t[0], t[1:]...))
+				if err != nil {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 				}
 			}
-		}
-		if len(dups) > 0 {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("duplicates %+v", dups))
-		}
 
-		for _, role := range adding {
-			err := validateRole(role)
-			if err != nil {
-				err = fmt.Errorf("%s failed validation: %+v", role.Name, err)
-				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
-			}
-
-			err = existingRoles.Add(role)
+			existingRoles, err := GetRoles()
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 			}
-		}
 
-		if err = modifyCommonConfigMap(existingRoles); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
-		}
-	},
-}
+			adding := rff.Instances()
+			var dups []string
+			for _, role := range adding {
+				if existingRoles.Get(role.RoleKey) != nil {
+					var dup bool
+					if dup {
+						dups = append(dups, role.Name)
+					}
+				}
+			}
+			if len(dups) > 0 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("duplicates %+v", dups))
+			}
 
-func init() {
-	roleCmd.AddCommand(roleCreateCmd)
+			for _, role := range adding {
+				err := validateRole(role)
+				if err != nil {
+					err = fmt.Errorf("%s failed validation: %+v", role.Name, err)
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
+				}
+
+				err = existingRoles.Add(role)
+				if err != nil {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
+				}
+			}
+
+			if err = modifyCommonConfigMap(existingRoles); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
+			}
+		},
+	}
+
 	roleCreateCmd.Flags().StringSlice("role", []string{}, "role in the form <name>=<type>=<id>=<pool>=<quota>")
+	return roleCreateCmd
 }
 
 func modifyCommonConfigMap(roles *roles.JSON) error {

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -117,7 +116,7 @@ func Test_Unit_RoleCreate(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			roleArg, wantCode := tc(t)
-			cmd := rootCmd
+			cmd := NewRootCmd()
 			cmd.SetArgs([]string{"role", "create", roleArg})
 			var (
 				outBuf, errBuf bytes.Buffer
@@ -198,9 +197,8 @@ func Test_Unit_RoleCreate_PowerMax(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			roleArg, wantCode := tc(t)
-			cmd := rootCmd
+			cmd := NewRootCmd()
 			cmd.SetArgs([]string{"role", "create", roleArg})
-			t.Logf("%+v", cmd)
 			var (
 				outBuf, errBuf bytes.Buffer
 			)
@@ -222,8 +220,7 @@ func Test_Unit_RoleCreate_PowerMax(t *testing.T) {
 				done <- struct{}{}
 			}()
 			<-done
-			log.Println(string(outBuf.Bytes()))
-			log.Println(string(errBuf.Bytes()))
+
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,11 +254,6 @@ func TestK3sRoleSubprocessPowerMax(t *testing.T) {
 		}
 	}
 
-	file, err := os.OpenFile("/tmp/test.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		//
-	}
-	fmt.Fprintf(file, "RETURN_FILE: %q\n", returnFile)
 	// k3s kubectl [get,create,apply]
 	switch os.Args[2] {
 	case "get":

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -148,3 +148,121 @@ func Test_Unit_RoleCreate(t *testing.T) {
 		})
 	}
 }
+
+func Test_Unit_RoleCreate_PowerMax(t *testing.T) {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(
+			context.Background(),
+			os.Args[0],
+			append([]string{
+				"-test.run=TestK3sRoleSubprocessPowerMax",
+				"--",
+				name}, args...)...)
+		cmd.Env = append(os.Environ(), "WANT_GO_TEST_SUBPROCESS=1")
+
+		return cmd
+	}
+	defer func() {
+		execCommandContext = exec.CommandContext
+	}()
+
+	// Creates a fake powermax handler
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/univmax/restapi/version":
+				fmt.Fprintf(w, `{ "version": "V9.2.1.2"}`)
+			case "/univmax/restapi/91/sloprovisioning/symmetrix/000197900714/srp/bronze":
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unhandled unisphere request path: %s", r.URL.Path)
+			}
+		}))
+	defer ts.Close()
+
+	oldGetPowerMaxEndpoint := GetPowerMaxEndpoint
+	GetPowerMaxEndpoint = func(storageSystemDetails System) string {
+		return ts.URL
+	}
+	defer func() { GetPowerMaxEndpoint = oldGetPowerMaxEndpoint }()
+
+	tests := map[string]func(t *testing.T) (string, int){
+		"success creating role with json file": func(*testing.T) (string, int) {
+			return "--role=NewRole1=powermax=000197900714=bronze=9000000", 0
+		},
+		"failure creating role with negative quota": func(*testing.T) (string, int) {
+			return "--role=NewRole2=powermax=000197900714=bronze=-2", 1
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			roleArg, wantCode := tc(t)
+			cmd := rootCmd
+			cmd.SetArgs([]string{"role", "create", roleArg})
+			var (
+				outBuf, errBuf bytes.Buffer
+			)
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&errBuf)
+
+			var gotCode int
+			done := make(chan struct{})
+			osExit = func(code int) {
+				gotCode = code
+				done <- struct{}{}
+				select {}
+			}
+			defer func() { osExit = os.Exit }()
+
+			var err error
+			go func() {
+				err = cmd.Execute()
+				done <- struct{}{}
+			}()
+			<-done
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if gotCode != wantCode {
+				t.Errorf("exitCode: got %v, want %v", gotCode, wantCode)
+			}
+		})
+	}
+}
+
+// This test case is intended to run as a subprocess.
+func TestK3sRoleSubprocessPowerMax(t *testing.T) {
+	if v := os.Getenv("WANT_GO_TEST_SUBPROCESS"); v != "1" {
+		t.Skip("not being run as a subprocess")
+	}
+
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = os.Args[i+1:]
+			break
+		}
+	}
+	defer os.Exit(0)
+
+	returnFile := "testdata/common-configmap.json"
+
+	// k3s commands may be for access roles using 'common' configmap or for storage using the 'karavi-storage-secret' secret
+	for _, arg := range os.Args {
+		if arg == "secret/karavi-storage-secret" {
+			returnFile = "testdata/kubectl_get_secret_storage_powerflex_powermax.json"
+		}
+	}
+
+	// k3s kubectl [get,create,apply]
+	switch os.Args[2] {
+	case "get":
+		b, err := ioutil.ReadFile(returnFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = io.Copy(os.Stdout, bytes.NewReader(b)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/karavictl/cmd/role_delete_test.go
+++ b/cmd/karavictl/cmd/role_delete_test.go
@@ -47,7 +47,7 @@ func Test_Unit_RoleDelete(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			rolesToDelete, wantCode := tc(t)
-			cmd := rootCmd
+			cmd := NewRootCmd()
 			args := []string{"role", "delete"}
 			for _, role := range rolesToDelete {
 				args = append(args, role)

--- a/cmd/karavictl/cmd/role_get.go
+++ b/cmd/karavictl/cmd/role_get.go
@@ -26,58 +26,58 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var roleGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get role",
-	Long:  `Get role`,
-	Run: func(cmd *cobra.Command, args []string) {
+// NewRoleGetCmd creates a new role get command
+func NewRoleGetCmd() *cobra.Command {
+	roleGetCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get role",
+		Long:  `Get role`,
+		Run: func(cmd *cobra.Command, args []string) {
 
-		if len(args) == 0 {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("role name is required"))
-		}
-
-		if len(args) > 1 {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("expects single argument"))
-		}
-
-		r, err := GetRoles()
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to list roles: %v", err))
-		}
-
-		roleName := strings.TrimSpace(args[0])
-
-		matches := []roles.Instance{}
-		r.Select(func(r roles.Instance) {
-			if r.Name == roleName {
-				matches = append(matches, r)
+			if len(args) == 0 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("role name is required"))
 			}
-		})
-		if len(matches) == 0 {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("role %s does not exist", roleName))
-		}
 
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(&r); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		var m map[string]interface{}
-		if err := json.NewDecoder(&buf).Decode(&m); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		for k := range m {
-			if k != roleName {
-				delete(m, k)
+			if len(args) > 1 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("expects single argument"))
 			}
-		}
 
-		err = JSONOutput(cmd.OutOrStdout(), m)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to format json output: %v", err))
-		}
-	},
-}
+			r, err := GetRoles()
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to list roles: %v", err))
+			}
 
-func init() {
-	roleCmd.AddCommand(roleGetCmd)
+			roleName := strings.TrimSpace(args[0])
+
+			matches := []roles.Instance{}
+			r.Select(func(r roles.Instance) {
+				if r.Name == roleName {
+					matches = append(matches, r)
+				}
+			})
+			if len(matches) == 0 {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("role %s does not exist", roleName))
+			}
+
+			var buf bytes.Buffer
+			if err := json.NewEncoder(&buf).Encode(&r); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			var m map[string]interface{}
+			if err := json.NewDecoder(&buf).Decode(&m); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			for k := range m {
+				if k != roleName {
+					delete(m, k)
+				}
+			}
+
+			err = JSONOutput(cmd.OutOrStdout(), m)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to format json output: %v", err))
+			}
+		},
+	}
+	return roleGetCmd
 }

--- a/cmd/karavictl/cmd/role_get_test.go
+++ b/cmd/karavictl/cmd/role_get_test.go
@@ -42,7 +42,8 @@ func Test_Unit_RoleGet(t *testing.T) {
 
 	tests := map[string]func(t *testing.T) ([]string, int){
 		"success getting existing role": func(*testing.T) ([]string, int) {
-			return []string{"--role=CSIGold"}, 0
+			// --role=CSIGold not supported
+			return []string{"CSIGold"}, 0
 		},
 	}
 
@@ -51,7 +52,7 @@ func Test_Unit_RoleGet(t *testing.T) {
 
 			rolesToGet, wantCode := tc(t)
 
-			cmd := rootCmd
+			cmd := NewRootCmd()
 
 			args := []string{"role", "get"}
 			for _, role := range rolesToGet {

--- a/cmd/karavictl/cmd/role_list.go
+++ b/cmd/karavictl/cmd/role_list.go
@@ -20,23 +20,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var roleListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List roles",
-	Long:  `List roles`,
-	Run: func(cmd *cobra.Command, args []string) {
-		roles, err := GetRoles()
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to list roles: %v", err))
-		}
+// NewRoleListCmd creates a new role list command
+func NewRoleListCmd() *cobra.Command {
+	roleListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List roles",
+		Long:  `List roles`,
+		Run: func(cmd *cobra.Command, args []string) {
+			roles, err := GetRoles()
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to list roles: %v", err))
+			}
 
-		err = JSONOutput(cmd.OutOrStdout(), &roles)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to format json output: %v", err))
-		}
-	},
-}
-
-func init() {
-	roleCmd.AddCommand(roleListCmd)
+			err = JSONOutput(cmd.OutOrStdout(), &roles)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to format json output: %v", err))
+			}
+		},
+	}
+	return roleListCmd
 }

--- a/cmd/karavictl/cmd/role_list_test.go
+++ b/cmd/karavictl/cmd/role_list_test.go
@@ -54,7 +54,7 @@ func Test_Unit_RoleList(t *testing.T) {
 
 			expectedRoleQuotas := tc(t)
 
-			cmd := rootCmd
+			cmd := NewRootCmd()
 			cmd.SetArgs([]string{"role", "list"})
 
 			stdOut := bytes.NewBufferString("")

--- a/cmd/karavictl/cmd/role_update_test.go
+++ b/cmd/karavictl/cmd/role_update_test.go
@@ -109,7 +109,7 @@ func Test_Unit_RoleUpdate(t *testing.T) {
 	}
 	for name := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := rootCmd
+			cmd := NewRootCmd()
 			cmd.SetArgs([]string{"role", "update",
 				"--role=CSIBronze=powerflex=542a2d5f5122210f=bronze=9000000"})
 			var (

--- a/cmd/karavictl/cmd/rolebinding.go
+++ b/cmd/karavictl/cmd/rolebinding.go
@@ -21,22 +21,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rolebindingCmd represents the rolebinding command
-var rolebindingCmd = &cobra.Command{
-	Use:   "rolebinding",
-	Short: "Manage role bindings",
-	Long:  `Management for role bindings`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Usage(); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("error: %+v", err))
-		}
-		os.Exit(1)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(rolebindingCmd)
-
+// NewRoleBindingCmd creates a new rolebinding command
+func NewRoleBindingCmd() *cobra.Command {
+	rolebindingCmd := &cobra.Command{
+		Use:   "rolebinding",
+		Short: "Manage role bindings",
+		Long:  `Management for role bindings`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Usage(); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("error: %+v", err))
+			}
+			os.Exit(1)
+		},
+	}
 	rolebindingCmd.PersistentFlags().String("addr", "localhost:443", "Address of the server")
 	rolebindingCmd.PersistentFlags().Bool("insecure", false, "For insecure connections")
+	return rolebindingCmd
 }

--- a/cmd/karavictl/cmd/rolebinding.go
+++ b/cmd/karavictl/cmd/rolebinding.go
@@ -36,5 +36,8 @@ func NewRoleBindingCmd() *cobra.Command {
 	}
 	rolebindingCmd.PersistentFlags().String("addr", "localhost:443", "Address of the server")
 	rolebindingCmd.PersistentFlags().Bool("insecure", false, "For insecure connections")
+
+	rolebindingCmd.AddCommand(NewCreateRoleBindingCmd())
+	rolebindingCmd.AddCommand(NewDeleteRoleBindingCmd())
 	return rolebindingCmd
 }

--- a/cmd/karavictl/cmd/rolebinding_create.go
+++ b/cmd/karavictl/cmd/rolebinding_create.go
@@ -17,62 +17,61 @@ package cmd
 import (
 	"context"
 	"errors"
-	"github.com/spf13/cobra"
 	"karavi-authorization/pb"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
-// createRoleBindingCmd represents the rolebinding command
-var createRoleBindingCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a rolebinding between role and tenant",
-	Long:  `Creates a rolebinding between role and tenant`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewCreateRoleBindingCmd creates a new rolebinding command
+func NewCreateRoleBindingCmd() *cobra.Command {
+	createRoleBindingCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a rolebinding between role and tenant",
+		Long:  `Creates a rolebinding between role and tenant`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenant, err := cmd.Flags().GetString("tenant")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		role, err := cmd.Flags().GetString("role")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			tenant, err := cmd.Flags().GetString("tenant")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			role, err := cmd.Flags().GetString("role")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		if strings.TrimSpace(tenant) == "" {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no tenant input provided"))
-		}
+			if strings.TrimSpace(tenant) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no tenant input provided"))
+			}
 
-		if strings.TrimSpace(role) == "" {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no role input provided"))
-		}
+			if strings.TrimSpace(role) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("no role input provided"))
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		_, err = tenantClient.BindRole(context.Background(), &pb.BindRoleRequest{
-			TenantName: tenant,
-			RoleName:   role,
-		})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	rolebindingCmd.AddCommand(createRoleBindingCmd)
+			_, err = tenantClient.BindRole(context.Background(), &pb.BindRoleRequest{
+				TenantName: tenant,
+				RoleName:   role,
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
 	createRoleBindingCmd.Flags().StringP("tenant", "t", "", "Tenant name")
 	err := createRoleBindingCmd.MarkFlagRequired("tenant")
@@ -84,4 +83,6 @@ func init() {
 	if err != nil {
 		reportErrorAndExit(JSONOutput, createRoleBindingCmd.ErrOrStderr(), err)
 	}
+
+	return createRoleBindingCmd
 }

--- a/cmd/karavictl/cmd/rolebinding_create_test.go
+++ b/cmd/karavictl/cmd/rolebinding_create_test.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"google.golang.org/grpc"
 	"io"
 	"io/ioutil"
 	"karavi-authorization/pb"
 	"os"
 	"testing"
+
+	"google.golang.org/grpc"
 )
 
 func TestRolebindingCreate(t *testing.T) {
@@ -47,9 +48,10 @@ func TestRolebindingCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
-		rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		cmd.Execute()
 
 		if !gotCalled {
 			t.Error("expected BindRole to be called, but it wasn't")
@@ -69,9 +71,10 @@ func TestRolebindingCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
-		go rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1
@@ -105,10 +108,11 @@ func TestRolebindingCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		createRoleBindingCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
 
-		go rootCmd.Execute()
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1

--- a/cmd/karavictl/cmd/rolebinding_delete.go
+++ b/cmd/karavictl/cmd/rolebinding_delete.go
@@ -21,50 +21,48 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteRoleBindingCmd represents the rolebinding command
-var deleteRoleBindingCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete a rolebinding between role and tenant",
-	Long:  `Deletes a rolebinding between role and tenant`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewDeleteRoleBindingCmd creates a new rolebinding command
+func NewDeleteRoleBindingCmd() *cobra.Command {
+	deleteRoleBindingCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a rolebinding between role and tenant",
+		Long:  `Deletes a rolebinding between role and tenant`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		tenant, err := cmd.Flags().GetString("tenant")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		role, err := cmd.Flags().GetString("role")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			tenant, err := cmd.Flags().GetString("tenant")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			role, err := cmd.Flags().GetString("role")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		_, err = tenantClient.UnbindRole(context.Background(), &pb.UnbindRoleRequest{
-			TenantName: tenant,
-			RoleName:   role,
-		})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	rolebindingCmd.AddCommand(deleteRoleBindingCmd)
-
+			_, err = tenantClient.UnbindRole(context.Background(), &pb.UnbindRoleRequest{
+				TenantName: tenant,
+				RoleName:   role,
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 	deleteRoleBindingCmd.Flags().StringP("tenant", "t", "", "Tenant name")
 	deleteRoleBindingCmd.Flags().StringP("role", "r", "", "Role name")
+	return deleteRoleBindingCmd
 }

--- a/cmd/karavictl/cmd/rolebinding_delete_test.go
+++ b/cmd/karavictl/cmd/rolebinding_delete_test.go
@@ -48,7 +48,10 @@ func TestRolebindingDelete(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
+		rootCmd := NewRootCmd()
+		deleteRoleBindingCmd := NewDeleteRoleBindingCmd()
+
+		deleteRoleBindingCmd.SetOutput(&gotOutput)
 		rootCmd.SetArgs([]string{"rolebinding", "delete"})
 		rootCmd.Execute()
 
@@ -69,6 +72,9 @@ func TestRolebindingDelete(t *testing.T) {
 			done <- struct{}{} // we can't let this function return
 		}
 		var gotOutput bytes.Buffer
+
+		rootCmd := NewRootCmd()
+		//deleteRoleBindingCmd := NewDeleteRoleBindingCmd()
 
 		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"rolebinding", "delete"})
@@ -106,10 +112,11 @@ func TestRolebindingDelete(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		deleteRoleBindingCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"rolebinding", "delete"})
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"rolebinding", "delete"})
 
-		go rootCmd.Execute()
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1

--- a/cmd/karavictl/cmd/rolebinding_delete_test.go
+++ b/cmd/karavictl/cmd/rolebinding_delete_test.go
@@ -74,7 +74,6 @@ func TestRolebindingDelete(t *testing.T) {
 		var gotOutput bytes.Buffer
 
 		rootCmd := NewRootCmd()
-		//deleteRoleBindingCmd := NewDeleteRoleBindingCmd()
 
 		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"rolebinding", "delete"})

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -32,27 +32,73 @@ const (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "karavictl",
-	Short: "karavictl is used to interact with karavi server",
-	Long: `karavictl provides security, RBAC, and quota limits for accessing Dell EMC
-storage products from Kubernetes clusters`,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
-func init() {
+// NewRootCmd creates a new base command when called without any subcommands
+func NewRootCmd() *cobra.Command {
 	cobra.OnInitialize(initConfig)
+
+	rootCmd := &cobra.Command{
+		Use:   "karavictl",
+		Short: "karavictl is used to interact with karavi server",
+		Long: `karavictl provides security, RBAC, and quota limits for accessing Dell EMC
+	storage products from Kubernetes clusters`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Execute(); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		},
+	}
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.karavictl.yaml)")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	addRoleCmds(rootCmd)
+	addRoleBindingCmds(rootCmd)
+	addStorageCmds(rootCmd)
+	addTenatCmds(rootCmd)
+	addInjectCmds(rootCmd)
+	return rootCmd
+}
+
+func addRoleCmds(rootCmd *cobra.Command) {
+	roleCmd := NewRoleCmd()
+	roleCmd.AddCommand(NewRoleCreateCmd())
+	roleCmd.AddCommand(NewRoleDeleteCmd())
+	roleCmd.AddCommand(NewRoleGetCmd())
+	roleCmd.AddCommand(NewRoleListCmd())
+	roleCmd.AddCommand(NewRoleUpdateCmd())
+	rootCmd.AddCommand(roleCmd)
+}
+
+func addRoleBindingCmds(rootCmd *cobra.Command) {
+	rolebindingCmd := NewRoleBindingCmd()
+	rolebindingCmd.AddCommand(NewCreateRoleBindingCmd())
+	rolebindingCmd.AddCommand(NewDeleteRoleBindingCmd())
+	rootCmd.AddCommand(rolebindingCmd)
+}
+
+func addStorageCmds(rootCmd *cobra.Command) {
+	storageCmd := NewStorageCmd()
+	storageCmd.AddCommand(NewStorageCreateCmd())
+	storageCmd.AddCommand(NewStorageDeleteCmd())
+	storageCmd.AddCommand(NewStorageGetCmd())
+	storageCmd.AddCommand(NewStorageListCmd())
+	storageCmd.AddCommand(NewStorageUpdateCmd())
+	rootCmd.AddCommand(storageCmd)
+}
+
+func addTenatCmds(rootCmd *cobra.Command) {
+	tenantCmd := NewTenantCmd()
+	tenantCmd.AddCommand(NewTenantCreateCmd())
+	tenantCmd.AddCommand(NewTenantDeleteCmd())
+	tenantCmd.AddCommand(NewTenantGetCmd())
+	tenantCmd.AddCommand(NewTenantListCmd())
+	tenantCmd.AddCommand(NewTenantRevokeCmd())
+	rootCmd.AddCommand(tenantCmd)
+}
+
+func addInjectCmds(rootCmd *cobra.Command) {
+	injectCmd := NewInjectCmd()
+	rootCmd.AddCommand(injectCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -51,54 +51,14 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.karavictl.yaml)")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	addRoleCmds(rootCmd)
-	addRoleBindingCmds(rootCmd)
-	addStorageCmds(rootCmd)
-	addTenatCmds(rootCmd)
-	addInjectCmds(rootCmd)
+	rootCmd.AddCommand(NewRoleCmd())
+	rootCmd.AddCommand(NewRoleBindingCmd())
+	rootCmd.AddCommand(NewTenantCmd())
+	rootCmd.AddCommand(NewInjectCmd())
+	rootCmd.AddCommand(NewClusterInfoCmd())
+	rootCmd.AddCommand(NewGenerateCmd())
+	rootCmd.AddCommand(NewStorageCmd())
 	return rootCmd
-}
-
-func addRoleCmds(rootCmd *cobra.Command) {
-	roleCmd := NewRoleCmd()
-	roleCmd.AddCommand(NewRoleCreateCmd())
-	roleCmd.AddCommand(NewRoleDeleteCmd())
-	roleCmd.AddCommand(NewRoleGetCmd())
-	roleCmd.AddCommand(NewRoleListCmd())
-	roleCmd.AddCommand(NewRoleUpdateCmd())
-	rootCmd.AddCommand(roleCmd)
-}
-
-func addRoleBindingCmds(rootCmd *cobra.Command) {
-	rolebindingCmd := NewRoleBindingCmd()
-	rolebindingCmd.AddCommand(NewCreateRoleBindingCmd())
-	rolebindingCmd.AddCommand(NewDeleteRoleBindingCmd())
-	rootCmd.AddCommand(rolebindingCmd)
-}
-
-func addStorageCmds(rootCmd *cobra.Command) {
-	storageCmd := NewStorageCmd()
-	storageCmd.AddCommand(NewStorageCreateCmd())
-	storageCmd.AddCommand(NewStorageDeleteCmd())
-	storageCmd.AddCommand(NewStorageGetCmd())
-	storageCmd.AddCommand(NewStorageListCmd())
-	storageCmd.AddCommand(NewStorageUpdateCmd())
-	rootCmd.AddCommand(storageCmd)
-}
-
-func addTenatCmds(rootCmd *cobra.Command) {
-	tenantCmd := NewTenantCmd()
-	tenantCmd.AddCommand(NewTenantCreateCmd())
-	tenantCmd.AddCommand(NewTenantDeleteCmd())
-	tenantCmd.AddCommand(NewTenantGetCmd())
-	tenantCmd.AddCommand(NewTenantListCmd())
-	tenantCmd.AddCommand(NewTenantRevokeCmd())
-	rootCmd.AddCommand(tenantCmd)
-}
-
-func addInjectCmds(rootCmd *cobra.Command) {
-	injectCmd := NewInjectCmd()
-	rootCmd.AddCommand(injectCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/karavictl/cmd/storage.go
+++ b/cmd/karavictl/cmd/storage.go
@@ -21,19 +21,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// storageCmd represents the storage command
-var storageCmd = &cobra.Command{
-	Use:   "storage",
-	Short: "Manage storage systems",
-	Long:  `Manages storage systems`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Usage(); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %+v\n", err)
-		}
-		os.Exit(1)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(storageCmd)
+// NewStorageCmd creates a new storage command
+func NewStorageCmd() *cobra.Command {
+	storageCmd := &cobra.Command{
+		Use:   "storage",
+		Short: "Manage storage systems",
+		Long:  `Manages storage systems`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Usage(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+			}
+			os.Exit(1)
+		},
+	}
+	return storageCmd
 }

--- a/cmd/karavictl/cmd/storage.go
+++ b/cmd/karavictl/cmd/storage.go
@@ -34,5 +34,11 @@ func NewStorageCmd() *cobra.Command {
 			os.Exit(1)
 		},
 	}
+
+	storageCmd.AddCommand(NewStorageCreateCmd())
+	storageCmd.AddCommand(NewStorageDeleteCmd())
+	storageCmd.AddCommand(NewStorageGetCmd())
+	storageCmd.AddCommand(NewStorageListCmd())
+	storageCmd.AddCommand(NewStorageUpdateCmd())
 	return storageCmd
 }

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -318,4 +318,5 @@ func setDefaultFlags(t *testing.T, cmd *cobra.Command) {
 	setFlag(t, storageCreateCmd, "user", "admin")
 	setFlag(t, storageCreateCmd, "password", "password")
 	setFlag(t, storageCreateCmd, "insecure", "true")
+	setFlag(t, storageCreateCmd, "system-id", "")
 }

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -182,37 +182,41 @@ func TestStorageCreateCmd(t *testing.T) {
 
 	t.Run("happy path powerflex", func(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/powerflex_api_types_System_instances_testing123.json"
-		setDefaultFlags(t, storageCreateCmd)
-		setFlag(t, storageCreateCmd, "endpoint", pfts.URL)
-		setFlag(t, storageCreateCmd, "system-id", "testing123")
-		setFlag(t, storageCreateCmd, "type", "powerflex")
-		storageCreateCmd.Run(storageCreateCmd, nil)
+		cmd := NewStorageCreateCmd()
+		setDefaultStorageFlags(t, cmd)
+		setFlag(t, cmd, "endpoint", pfts.URL)
+		setFlag(t, cmd, "system-id", "testing123")
+		setFlag(t, cmd, "type", "powerflex")
+		cmd.Run(cmd, nil)
 	})
 
 	t.Run("happy path unisphere all", func(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/unisphere_api_types_System_instances_testing.json"
-		setDefaultFlags(t, storageCreateCmd)
-		setFlag(t, storageCreateCmd, "endpoint", usts.URL)
-		setFlag(t, storageCreateCmd, "type", "powermax")
-		storageCreateCmd.Run(storageCreateCmd, nil)
+		cmd := NewStorageCreateCmd()
+		setDefaultStorageFlags(t, cmd)
+		setFlag(t, cmd, "endpoint", usts.URL)
+		setFlag(t, cmd, "type", "powermax")
+		cmd.Run(cmd, nil)
 	})
 
 	t.Run("happy path unisphere allowlist", func(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/unisphere_api_types_System_instances_testing.json"
-		setDefaultFlags(t, storageCreateCmd)
-		setFlag(t, storageCreateCmd, "endpoint", usts.URL)
-		setFlag(t, storageCreateCmd, "system-id", "testing1,testing2")
-		setFlag(t, storageCreateCmd, "type", "powermax")
-		storageCreateCmd.Run(storageCreateCmd, nil)
+		cmd := NewStorageCreateCmd()
+		setDefaultStorageFlags(t, cmd)
+		setFlag(t, cmd, "endpoint", usts.URL)
+		setFlag(t, cmd, "system-id", "testing1,testing2")
+		setFlag(t, cmd, "type", "powermax")
+		cmd.Run(cmd, nil)
 	})
 
 	t.Run("prevents duplicate system registration", func(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/powerflex_api_types_System_instances_542a2d5f5122210f.json"
-		setDefaultFlags(t, storageCreateCmd)
-		setFlag(t, storageCreateCmd, "endpoint", pfts.URL)
-		setFlag(t, storageCreateCmd, "system-id", "542a2d5f5122210f")
+		cmd := NewStorageCreateCmd()
+		setDefaultStorageFlags(t, cmd)
+		setFlag(t, cmd, "endpoint", pfts.URL)
+		setFlag(t, cmd, "system-id", "542a2d5f5122210f")
 		var out bytes.Buffer
-		storageCreateCmd.SetErr(&out)
+		cmd.SetErr(&out)
 
 		done := make(chan struct{})
 		wantExitCode := 1
@@ -224,7 +228,7 @@ func TestStorageCreateCmd(t *testing.T) {
 		}
 		defer func() { osExit = os.Exit }()
 
-		go storageCreateCmd.Run(storageCreateCmd, nil)
+		go cmd.Run(cmd, nil)
 		<-done
 
 		if gotExitCode != wantExitCode {
@@ -237,11 +241,12 @@ func TestStorageCreateCmd(t *testing.T) {
 	})
 
 	t.Run("system not found", func(t *testing.T) {
-		setDefaultFlags(t, storageCreateCmd)
-		setFlag(t, storageCreateCmd, "endpoint", pfts.URL)
-		setFlag(t, storageCreateCmd, "system-id", "missing-system-id")
+		cmd := NewStorageCreateCmd()
+		setDefaultStorageFlags(t, cmd)
+		setFlag(t, cmd, "endpoint", pfts.URL)
+		setFlag(t, cmd, "system-id", "missing-system-id")
 		var out bytes.Buffer
-		storageCreateCmd.SetErr(&out)
+		cmd.SetErr(&out)
 
 		done := make(chan struct{})
 		wantExitCode := 1
@@ -253,7 +258,7 @@ func TestStorageCreateCmd(t *testing.T) {
 		}
 		defer func() { osExit = os.Exit }()
 
-		go storageCreateCmd.Run(storageCreateCmd, nil)
+		go cmd.Run(cmd, nil)
 		<-done
 
 		if gotExitCode != wantExitCode {
@@ -313,10 +318,10 @@ func Test_readPassword(t *testing.T) {
 	})
 }
 
-func setDefaultFlags(t *testing.T, cmd *cobra.Command) {
-	setFlag(t, storageCreateCmd, "type", "powerflex")
-	setFlag(t, storageCreateCmd, "user", "admin")
-	setFlag(t, storageCreateCmd, "password", "password")
-	setFlag(t, storageCreateCmd, "insecure", "true")
-	setFlag(t, storageCreateCmd, "system-id", "")
+func setDefaultStorageFlags(t *testing.T, cmd *cobra.Command) {
+	setFlag(t, cmd, "type", "powerflex")
+	setFlag(t, cmd, "user", "admin")
+	setFlag(t, cmd, "password", "password")
+	setFlag(t, cmd, "insecure", "true")
+	setFlag(t, cmd, "system-id", "")
 }

--- a/cmd/karavictl/cmd/storage_get.go
+++ b/cmd/karavictl/cmd/storage_get.go
@@ -30,88 +30,86 @@ var (
 	errSystemIDNotSpecified   = errors.New("system id not specified")
 )
 
-// getCmd represents the get command
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get details on a registered storage system.",
-	Long:  `Gets details on a registered storage system.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+// NewStorageGetCmd creates a new get command
+func NewStorageGetCmd() *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get details on a registered storage system.",
+		Long:  `Gets details on a registered storage system.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		errAndExit := func(err error) {
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
-			osExit(1)
-		}
-
-		sysType, err := cmd.Flags().GetString("type")
-		if err != nil {
-			errAndExit(err)
-		}
-		if sysType == "" {
-			errAndExit(errSystemTypeNotSpecified)
-		}
-
-		sysID, err := cmd.Flags().GetString("system-id")
-		if err != nil {
-			errAndExit(err)
-		}
-		if sysID == "" {
-			errAndExit(errSystemIDNotSpecified)
-		}
-
-		// Get the current list of registered storage systems
-		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
-			"--namespace=karavi",
-			"--output=json",
-			"secret/karavi-storage-secret")
-
-		b, err := k3sCmd.Output()
-		if err != nil {
-			errAndExit(err)
-		}
-		base64Systems := struct {
-			Data map[string]string
-		}{}
-		if err := json.Unmarshal(b, &base64Systems); err != nil {
-			errAndExit(err)
-		}
-		decodedSystems, err := base64.StdEncoding.DecodeString(base64Systems.Data["storage-systems.yaml"])
-		if err != nil {
-			errAndExit(err)
-		}
-
-		var listData map[string]Storage
-		if err := yaml.Unmarshal(decodedSystems, &listData); err != nil {
-			errAndExit(err)
-		}
-		if listData == nil || listData["storage"] == nil {
-			listData = make(map[string]Storage)
-			listData["storage"] = make(Storage)
-		}
-		var storage = listData["storage"]
-
-		for k := range storage {
-			if k != sysType {
-				continue
-			}
-			id, ok := storage[k][sysID]
-			if !ok {
-				continue
+			errAndExit := func(err error) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
+				osExit(1)
 			}
 
-			id.Password = "(omitted)"
-			if err := JSONOutput(cmd.OutOrStdout(), &id); err != nil {
-				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			sysType, err := cmd.Flags().GetString("type")
+			if err != nil {
+				errAndExit(err)
 			}
-			break
-		}
-	},
-}
+			if sysType == "" {
+				errAndExit(errSystemTypeNotSpecified)
+			}
 
-func init() {
-	storageCmd.AddCommand(getCmd)
+			sysID, err := cmd.Flags().GetString("system-id")
+			if err != nil {
+				errAndExit(err)
+			}
+			if sysID == "" {
+				errAndExit(errSystemIDNotSpecified)
+			}
 
+			// Get the current list of registered storage systems
+			k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
+				"--namespace=karavi",
+				"--output=json",
+				"secret/karavi-storage-secret")
+
+			b, err := k3sCmd.Output()
+			if err != nil {
+				errAndExit(err)
+			}
+			base64Systems := struct {
+				Data map[string]string
+			}{}
+			if err := json.Unmarshal(b, &base64Systems); err != nil {
+				errAndExit(err)
+			}
+			decodedSystems, err := base64.StdEncoding.DecodeString(base64Systems.Data["storage-systems.yaml"])
+			if err != nil {
+				errAndExit(err)
+			}
+
+			var listData map[string]Storage
+			if err := yaml.Unmarshal(decodedSystems, &listData); err != nil {
+				errAndExit(err)
+			}
+			if listData == nil || listData["storage"] == nil {
+				listData = make(map[string]Storage)
+				listData["storage"] = make(Storage)
+			}
+			var storage = listData["storage"]
+
+			for k := range storage {
+				if k != sysType {
+					continue
+				}
+				id, ok := storage[k][sysID]
+				if !ok {
+					continue
+				}
+
+				id.Password = "(omitted)"
+				if err := JSONOutput(cmd.OutOrStdout(), &id); err != nil {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				}
+				break
+			}
+		},
+	}
 	getCmd.Flags().StringP("type", "t", "", "Type of storage system")
 	getCmd.Flags().StringP("system-id", "s", "", "System identifier")
+	return getCmd
 }

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -44,11 +44,12 @@ func TestStorageGetCmd(t *testing.T) {
 	}()
 
 	t.Run("get powerflex storage", func(t *testing.T) {
-		setFlag(t, getCmd, "type", "powerflex")
-		setFlag(t, getCmd, "system-id", "542a2d5f5122210f")
+		cmd := NewStorageGetCmd()
+		setFlag(t, cmd, "type", "powerflex")
+		setFlag(t, cmd, "system-id", "542a2d5f5122210f")
 		var out bytes.Buffer
-		getCmd.SetOut(&out)
-		getCmd.Run(getCmd, nil)
+		cmd.SetOut(&out)
+		cmd.Run(cmd, nil)
 
 		var sys System
 		err := json.Unmarshal(out.Bytes(), &sys)
@@ -63,11 +64,12 @@ func TestStorageGetCmd(t *testing.T) {
 	})
 
 	t.Run("get powermax storage", func(t *testing.T) {
-		setFlag(t, getCmd, "type", "powermax")
-		setFlag(t, getCmd, "system-id", "000197900714")
+		cmd := NewStorageGetCmd()
+		setFlag(t, cmd, "type", "powermax")
+		setFlag(t, cmd, "system-id", "000197900714")
 		var out bytes.Buffer
-		getCmd.SetOut(&out)
-		getCmd.Run(getCmd, nil)
+		cmd.SetOut(&out)
+		cmd.Run(cmd, nil)
 
 		var sys System
 		err := json.Unmarshal(out.Bytes(), &sys)
@@ -81,10 +83,11 @@ func TestStorageGetCmd(t *testing.T) {
 	})
 
 	t.Run("no storage type", func(t *testing.T) {
-		setFlag(t, getCmd, "type", "")
-		setFlag(t, getCmd, "system-id", "000197900714")
+		cmd := NewStorageGetCmd()
+		setFlag(t, cmd, "type", "")
+		setFlag(t, cmd, "system-id", "000197900714")
 		var out bytes.Buffer
-		getCmd.SetErr(&out)
+		cmd.SetErr(&out)
 
 		done := make(chan struct{})
 		wantExitCode := 1
@@ -96,7 +99,7 @@ func TestStorageGetCmd(t *testing.T) {
 		}
 		defer func() { osExit = os.Exit }()
 
-		go getCmd.Run(getCmd, nil)
+		go cmd.Run(cmd, nil)
 		<-done
 
 		if gotExitCode != wantExitCode {
@@ -109,10 +112,11 @@ func TestStorageGetCmd(t *testing.T) {
 	})
 
 	t.Run("no storage id", func(t *testing.T) {
-		setFlag(t, getCmd, "type", "powerflex")
-		setFlag(t, getCmd, "system-id", "")
+		cmd := NewStorageGetCmd()
+		setFlag(t, cmd, "type", "powerflex")
+		setFlag(t, cmd, "system-id", "")
 		var out bytes.Buffer
-		getCmd.SetErr(&out)
+		cmd.SetErr(&out)
 
 		done := make(chan struct{})
 		wantExitCode := 1
@@ -124,7 +128,7 @@ func TestStorageGetCmd(t *testing.T) {
 		}
 		defer func() { osExit = os.Exit }()
 
-		go getCmd.Run(getCmd, nil)
+		go cmd.Run(cmd, nil)
 		<-done
 
 		if gotExitCode != wantExitCode {

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -43,15 +43,17 @@ func TestStorageListCmd(t *testing.T) {
 	}()
 
 	t.Run("list all storage", func(t *testing.T) {
-		setFlag(t, listCmd, "type", "")
-		listCmd.Run(listCmd, nil)
+		cmd := NewStorageListCmd()
+		setFlag(t, cmd, "type", "")
+		cmd.Run(cmd, nil)
 	})
 
 	t.Run("list powerflex storage", func(t *testing.T) {
-		setFlag(t, listCmd, "type", "powerflex")
+		cmd := NewStorageListCmd()
+		setFlag(t, cmd, "type", "powerflex")
 		var out bytes.Buffer
-		listCmd.SetOut(&out)
-		listCmd.Run(listCmd, nil)
+		cmd.SetOut(&out)
+		cmd.Run(cmd, nil)
 
 		var sysType SystemType
 		err := json.Unmarshal(out.Bytes(), &sysType)
@@ -69,10 +71,11 @@ func TestStorageListCmd(t *testing.T) {
 	})
 
 	t.Run("list powermax storage", func(t *testing.T) {
-		setFlag(t, listCmd, "type", "powermax")
+		cmd := NewStorageListCmd()
+		setFlag(t, cmd, "type", "powermax")
 		var out bytes.Buffer
-		listCmd.SetOut(&out)
-		listCmd.Run(listCmd, nil)
+		cmd.SetOut(&out)
+		cmd.Run(cmd, nil)
 
 		var sysType SystemType
 		err := json.Unmarshal(out.Bytes(), &sysType)

--- a/cmd/karavictl/cmd/storage_update.go
+++ b/cmd/karavictl/cmd/storage_update.go
@@ -28,178 +28,175 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// storageUpdateCmd represents the storage update command
-var storageUpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update a registered storage system.",
-	Long:  `Updates a registered storage system.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// Get the storage systems and update it in place?
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+// NewStorageUpdateCmd creates a new update command
+func NewStorageUpdateCmd() *cobra.Command {
+	storageUpdateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a registered storage system.",
+		Long:  `Updates a registered storage system.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get the storage systems and update it in place?
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		errAndExit := func(err error) {
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
-			osExit(1)
-		}
+			errAndExit := func(err error) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "error: %+v\n", err)
+				osExit(1)
+			}
 
-		// Convenience functions for ignoring errors whilst
-		// getting flag values.
-		flagStringValue := func(v string, err error) string {
+			// Convenience functions for ignoring errors whilst
+			// getting flag values.
+			flagStringValue := func(v string, err error) string {
+				if err != nil {
+					errAndExit(err)
+				}
+				return v
+			}
+			flagBoolValue := func(v bool, err error) bool {
+				if err != nil {
+					errAndExit(err)
+				}
+				return v
+			}
+			verifyInput := func(v string) string {
+				inputText := flagStringValue(cmd.Flags().GetString(v))
+				if strings.TrimSpace(inputText) == "" {
+					errAndExit(fmt.Errorf("no input provided: %s", v))
+				}
+				return inputText
+			}
+
+			// Gather the inputs
+			var input = struct {
+				Type     string
+				Endpoint string
+				SystemID string
+				User     string
+				Password string
+				Insecure bool
+			}{
+				Type:     verifyInput("type"),
+				Endpoint: verifyInput("endpoint"),
+				SystemID: verifyInput("system-id"),
+				User:     verifyInput("user"),
+				Password: flagStringValue(cmd.Flags().GetString("password")),
+				Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
+			}
+
+			// Parse the URL and prepare for a password prompt.
+			urlWithUser, err := url.Parse(input.Endpoint)
 			if err != nil {
 				errAndExit(err)
 			}
-			return v
-		}
-		flagBoolValue := func(v bool, err error) bool {
+
+			urlWithUser.Scheme = "https"
+			urlWithUser.User = url.User(input.User)
+
+			// If the password was not provided...
+			prompt := fmt.Sprintf("Enter password for %v: ", urlWithUser)
+			// If the password was not provided...
+			if pf := cmd.Flags().Lookup("password"); !pf.Changed {
+				// Get password from stdin
+				readPassword(cmd.ErrOrStderr(), prompt, &input.Password)
+			}
+
+			// Sanitize the endpoint
+			epURL, err := url.Parse(input.Endpoint)
 			if err != nil {
 				errAndExit(err)
 			}
-			return v
-		}
-		verifyInput := func(v string) string {
-			inputText := flagStringValue(cmd.Flags().GetString(v))
-			if strings.TrimSpace(inputText) == "" {
-				errAndExit(fmt.Errorf("no input provided: %s", v))
-			}
-			return inputText
-		}
+			epURL.Scheme = "https"
 
-		// Gather the inputs
-		var input = struct {
-			Type     string
-			Endpoint string
-			SystemID string
-			User     string
-			Password string
-			Insecure bool
-		}{
-			Type:     verifyInput("type"),
-			Endpoint: verifyInput("endpoint"),
-			SystemID: verifyInput("system-id"),
-			User:     verifyInput("user"),
-			Password: flagStringValue(cmd.Flags().GetString("password")),
-			Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
-		}
+			k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
+				"--namespace=karavi",
+				"--output=json",
+				"secret/karavi-storage-secret")
 
-		// Parse the URL and prepare for a password prompt.
-		urlWithUser, err := url.Parse(input.Endpoint)
-		if err != nil {
-			errAndExit(err)
-		}
-
-		urlWithUser.Scheme = "https"
-		urlWithUser.User = url.User(input.User)
-
-		// If the password was not provided...
-		prompt := fmt.Sprintf("Enter password for %v: ", urlWithUser)
-		// If the password was not provided...
-		if pf := cmd.Flags().Lookup("password"); !pf.Changed {
-			// Get password from stdin
-			readPassword(cmd.ErrOrStderr(), prompt, &input.Password)
-		}
-
-		// Sanitize the endpoint
-		epURL, err := url.Parse(input.Endpoint)
-		if err != nil {
-			errAndExit(err)
-		}
-		epURL.Scheme = "https"
-
-		k3sCmd := execCommandContext(ctx, K3sPath, "kubectl", "get",
-			"--namespace=karavi",
-			"--output=json",
-			"secret/karavi-storage-secret")
-
-		b, err := k3sCmd.Output()
-		if err != nil {
-			errAndExit(err)
-		}
-
-		base64Systems := struct {
-			Data map[string]string
-		}{}
-		if err := json.Unmarshal(b, &base64Systems); err != nil {
-			errAndExit(err)
-		}
-		decodedSystems, err := base64.StdEncoding.DecodeString(base64Systems.Data["storage-systems.yaml"])
-		if err != nil {
-			errAndExit(err)
-		}
-
-		var listData map[string]Storage
-		if err := yaml.Unmarshal(decodedSystems, &listData); err != nil {
-			errAndExit(err)
-		}
-		if listData == nil || listData["storage"] == nil {
-			listData = make(map[string]Storage)
-			listData["storage"] = make(Storage)
-		}
-		var storage = listData["storage"]
-
-		var didUpdate bool
-		for k := range storage {
-			if k != input.Type {
-				continue
-			}
-			_, ok := storage[k][input.SystemID]
-			if !ok {
-				continue
+			b, err := k3sCmd.Output()
+			if err != nil {
+				errAndExit(err)
 			}
 
-			storage[k][input.SystemID] = System{
-				User:     input.User,
-				Password: input.Password,
-				Endpoint: input.Endpoint,
-				Insecure: input.Insecure,
+			base64Systems := struct {
+				Data map[string]string
+			}{}
+			if err := json.Unmarshal(b, &base64Systems); err != nil {
+				errAndExit(err)
 			}
-			didUpdate = true
-			break
-		}
-		if !didUpdate {
-			errAndExit(fmt.Errorf("no matching storage systems to update"))
-		}
-
-		listData["storage"] = storage
-		b, err = yaml.Marshal(&listData)
-		if err != nil {
-			errAndExit(err)
-		}
-
-		tmpFile, err := ioutil.TempFile("", "karavi")
-		if err != nil {
-			errAndExit(err)
-		}
-		defer func() {
-			if err := tmpFile.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+			decodedSystems, err := base64.StdEncoding.DecodeString(base64Systems.Data["storage-systems.yaml"])
+			if err != nil {
+				errAndExit(err)
 			}
-			if err := os.Remove(tmpFile.Name()); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+
+			var listData map[string]Storage
+			if err := yaml.Unmarshal(decodedSystems, &listData); err != nil {
+				errAndExit(err)
 			}
-		}()
-		_, err = tmpFile.WriteString(string(b))
-		if err != nil {
-			errAndExit(err)
-		}
+			if listData == nil || listData["storage"] == nil {
+				listData = make(map[string]Storage)
+				listData["storage"] = make(Storage)
+			}
+			var storage = listData["storage"]
 
-		crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
-			"--namespace=karavi",
-			"secret", "generic", "karavi-storage-secret",
-			fmt.Sprintf("--from-file=storage-systems.yaml=%s", tmpFile.Name()),
-			"--output=yaml",
-			"--dry-run=client")
-		appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
+			var didUpdate bool
+			for k := range storage {
+				if k != input.Type {
+					continue
+				}
+				_, ok := storage[k][input.SystemID]
+				if !ok {
+					continue
+				}
 
-		if err := pipeCommands(crtCmd, appCmd); err != nil {
-			errAndExit(err)
-		}
-	},
-}
+				storage[k][input.SystemID] = System{
+					User:     input.User,
+					Password: input.Password,
+					Endpoint: input.Endpoint,
+					Insecure: input.Insecure,
+				}
+				didUpdate = true
+				break
+			}
+			if !didUpdate {
+				errAndExit(fmt.Errorf("no matching storage systems to update"))
+			}
 
-func init() {
-	storageCmd.AddCommand(storageUpdateCmd)
+			listData["storage"] = storage
+			b, err = yaml.Marshal(&listData)
+			if err != nil {
+				errAndExit(err)
+			}
 
+			tmpFile, err := ioutil.TempFile("", "karavi")
+			if err != nil {
+				errAndExit(err)
+			}
+			defer func() {
+				if err := tmpFile.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+				}
+				if err := os.Remove(tmpFile.Name()); err != nil {
+					fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+				}
+			}()
+			_, err = tmpFile.WriteString(string(b))
+			if err != nil {
+				errAndExit(err)
+			}
+
+			crtCmd := execCommandContext(ctx, K3sPath, "kubectl", "create",
+				"--namespace=karavi",
+				"secret", "generic", "karavi-storage-secret",
+				fmt.Sprintf("--from-file=storage-systems.yaml=%s", tmpFile.Name()),
+				"--output=yaml",
+				"--dry-run=client")
+			appCmd := execCommandContext(ctx, K3sPath, "kubectl", "apply", "-f", "-")
+
+			if err := pipeCommands(crtCmd, appCmd); err != nil {
+				errAndExit(err)
+			}
+		},
+	}
 	storageUpdateCmd.Flags().StringP("type", "t", "", "Type of storage system")
 	err := storageUpdateCmd.MarkFlagRequired("type")
 	if err != nil {
@@ -222,4 +219,6 @@ func init() {
 	}
 	storageUpdateCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	storageUpdateCmd.Flags().BoolP("insecure", "i", false, "Insecure skip verify")
+
+	return storageUpdateCmd
 }

--- a/cmd/karavictl/cmd/tenant.go
+++ b/cmd/karavictl/cmd/tenant.go
@@ -48,6 +48,12 @@ func NewTenantCmd() *cobra.Command {
 	}
 	tenantCmd.PersistentFlags().String("addr", "localhost:443", "Address of the server")
 	tenantCmd.PersistentFlags().Bool("insecure", false, "For insecure connections")
+
+	tenantCmd.AddCommand(NewTenantCreateCmd())
+	tenantCmd.AddCommand(NewTenantDeleteCmd())
+	tenantCmd.AddCommand(NewTenantGetCmd())
+	tenantCmd.AddCommand(NewTenantListCmd())
+	tenantCmd.AddCommand(NewTenantRevokeCmd())
 	return tenantCmd
 }
 

--- a/cmd/karavictl/cmd/tenant.go
+++ b/cmd/karavictl/cmd/tenant.go
@@ -32,25 +32,23 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// tenantCmd represents the tenant command
-var tenantCmd = &cobra.Command{
-	Use:              "tenant",
-	TraverseChildren: true,
-	Short:            "Manage tenants",
-	Long:             `Management for tenants`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := cmd.Usage(); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %+v\n", err)
-		}
-		os.Exit(1)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(tenantCmd)
-
+// NewTenantCmd creates a new tenant command
+func NewTenantCmd() *cobra.Command {
+	tenantCmd := &cobra.Command{
+		Use:              "tenant",
+		TraverseChildren: true,
+		Short:            "Manage tenants",
+		Long:             `Management for tenants`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Usage(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+			}
+			os.Exit(1)
+		},
+	}
 	tenantCmd.PersistentFlags().String("addr", "localhost:443", "Address of the server")
 	tenantCmd.PersistentFlags().Bool("insecure", false, "For insecure connections")
+	return tenantCmd
 }
 
 // CommandError wraps errors for reporting.

--- a/cmd/karavictl/cmd/tenant_create.go
+++ b/cmd/karavictl/cmd/tenant_create.go
@@ -23,50 +23,49 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tenantCreateCmd represents the tenant command
-var tenantCreateCmd = &cobra.Command{
-	Use:              "create",
-	TraverseChildren: true,
-	Short:            "Create a tenant resource within Karavi",
-	Long:             `Creates a tenant resource within Karavi`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewTenantCreateCmd creates a new tenant command
+func NewTenantCreateCmd() *cobra.Command {
+	tenantCreateCmd := &cobra.Command{
+		Use:              "create",
+		TraverseChildren: true,
+		Short:            "Create a tenant resource within Karavi",
+		Long:             `Creates a tenant resource within Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		name, err := cmd.Flags().GetString("name")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		if strings.TrimSpace(name) == "" {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
-		}
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			if strings.TrimSpace(name) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
+			}
 
-		_, err = tenantClient.CreateTenant(context.Background(), &pb.CreateTenantRequest{
-			Tenant: &pb.Tenant{
-				Name: name,
-			},
-		})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	tenantCmd.AddCommand(tenantCreateCmd)
+			_, err = tenantClient.CreateTenant(context.Background(), &pb.CreateTenantRequest{
+				Tenant: &pb.Tenant{
+					Name: name,
+				},
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
 	tenantCreateCmd.Flags().StringP("name", "n", "", "Tenant name")
+	return tenantCreateCmd
 }

--- a/cmd/karavictl/cmd/tenant_create_test.go
+++ b/cmd/karavictl/cmd/tenant_create_test.go
@@ -47,9 +47,10 @@ func TestTenantCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "create", "-n", "testname"})
-		rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "create", "-n", "testname"})
+		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {
 			t.Errorf("expected zero output but got %q", string(gotOutput.Bytes()))
@@ -69,9 +70,10 @@ func TestTenantCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "create", "-n", "testname"})
-		go rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "create", "-n", "testname"})
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1
@@ -99,9 +101,11 @@ func TestTenantCreate(t *testing.T) {
 			done <- struct{}{}
 			done <- struct{}{} // we can't let this function return
 		}
-		setFlag(t, tenantCreateCmd, "name", "")
+
 		var gotOutput bytes.Buffer
-		tenantCreateCmd.SetErr(&gotOutput)
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "create"})
 
 		go rootCmd.Execute()
@@ -138,7 +142,8 @@ func TestTenantCreate(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		tenantCreateCmd.SetErr(&gotOutput)
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "create", "-n", "test"})
 
 		go rootCmd.Execute()

--- a/cmd/karavictl/cmd/tenant_delete.go
+++ b/cmd/karavictl/cmd/tenant_delete.go
@@ -23,47 +23,46 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tenantDeleteCmd represents the delete command
-var tenantDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete a tenant resource within Karavi",
-	Long:  `Deletes a tenant resource within Karavi`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewTenantDeleteCmd creates a new delete command
+func NewTenantDeleteCmd() *cobra.Command {
+	tenantDeleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a tenant resource within Karavi",
+		Long:  `Deletes a tenant resource within Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		name, err := cmd.Flags().GetString("name")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		if strings.TrimSpace(name) == "" {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
-		}
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			if strings.TrimSpace(name) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
+			}
 
-		_, err = tenantClient.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{
-			Name: name,
-		})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	tenantCmd.AddCommand(tenantDeleteCmd)
+			_, err = tenantClient.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{
+				Name: name,
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
 	tenantDeleteCmd.Flags().StringP("name", "n", "", "Tenant name")
+	return tenantDeleteCmd
 }

--- a/cmd/karavictl/cmd/tenant_delete_test.go
+++ b/cmd/karavictl/cmd/tenant_delete_test.go
@@ -49,9 +49,10 @@ func TestTenantDelete(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "delete", "-n", "testname"})
-		rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "delete", "-n", "testname"})
+		cmd.Execute()
 
 		if !gotCalled {
 			t.Error("expected DeleteTenant to be called, but it wasn't")
@@ -71,9 +72,10 @@ func TestTenantDelete(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "delete", "-n", "testname"})
-		go rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "delete", "-n", "testname"})
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1
@@ -101,9 +103,11 @@ func TestTenantDelete(t *testing.T) {
 			done <- struct{}{}
 			done <- struct{}{} // we can't let this function return
 		}
-		setFlag(t, tenantDeleteCmd, "name", "")
+
 		var gotOutput bytes.Buffer
-		tenantDeleteCmd.SetErr(&gotOutput)
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "delete"})
 
 		go rootCmd.Execute()
@@ -140,7 +144,8 @@ func TestTenantDelete(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		tenantDeleteCmd.SetErr(&gotOutput)
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "delete", "-n", "test"})
 
 		go rootCmd.Execute()

--- a/cmd/karavictl/cmd/tenant_get.go
+++ b/cmd/karavictl/cmd/tenant_get.go
@@ -23,52 +23,51 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tenantGetCmd represents the get command
-var tenantGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get a tenant resource within Karavi",
-	Long:  `Gets a tenant resource within Karavi`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewTenantGetCmd creates a new get command
+func NewTenantGetCmd() *cobra.Command {
+	tenantGetCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a tenant resource within Karavi",
+		Long:  `Gets a tenant resource within Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		name, err := cmd.Flags().GetString("name")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		if strings.TrimSpace(name) == "" {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
-		}
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			if strings.TrimSpace(name) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty name not allowed"))
+			}
 
-		t, err := tenantClient.GetTenant(context.Background(), &pb.GetTenantRequest{
-			Name: name,
-		})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			t, err := tenantClient.GetTenant(context.Background(), &pb.GetTenantRequest{
+				Name: name,
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		err = JSONOutput(cmd.OutOrStdout(), &t)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	tenantCmd.AddCommand(tenantGetCmd)
+			err = JSONOutput(cmd.OutOrStdout(), &t)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
 	tenantGetCmd.Flags().StringP("name", "n", "", "Tenant name")
+	return tenantGetCmd
 }

--- a/cmd/karavictl/cmd/tenant_get_test.go
+++ b/cmd/karavictl/cmd/tenant_get_test.go
@@ -42,9 +42,10 @@ func TestTenantGet(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "get", "-n", "testname"})
-		rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "get", "-n", "testname"})
+		cmd.Execute()
 
 		var resp pb.Tenant
 		if err := json.NewDecoder(&gotOutput).Decode(&resp); err != nil {
@@ -68,9 +69,10 @@ func TestTenantGet(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "get", "-n", "testname"})
-		go rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "get", "-n", "testname"})
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1
@@ -98,9 +100,11 @@ func TestTenantGet(t *testing.T) {
 			done <- struct{}{}
 			done <- struct{}{} // we can't let this function return
 		}
-		setFlag(t, tenantGetCmd, "name", "")
+
 		var gotOutput bytes.Buffer
-		tenantGetCmd.SetErr(&gotOutput)
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "get"})
 
 		go rootCmd.Execute()
@@ -137,7 +141,8 @@ func TestTenantGet(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		tenantGetCmd.SetErr(&gotOutput)
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "get", "-n", "test"})
 
 		go rootCmd.Execute()

--- a/cmd/karavictl/cmd/tenant_list.go
+++ b/cmd/karavictl/cmd/tenant_list.go
@@ -21,39 +21,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tenantListCmd represents the list command
-var tenantListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List a tenant resource within Karavi",
-	Long:  `Lists tenant resources within Karavi`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewTenantListCmd creates a new list command
+func NewTenantListCmd() *cobra.Command {
+	tenantListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List a tenant resource within Karavi",
+		Long:  `Lists tenant resources within Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		list, err := tenantClient.ListTenant(context.Background(), &pb.ListTenantRequest{})
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			list, err := tenantClient.ListTenant(context.Background(), &pb.ListTenantRequest{})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		if err := JSONOutput(cmd.OutOrStdout(), &list); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
+			if err := JSONOutput(cmd.OutOrStdout(), &list); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
-func init() {
-	tenantCmd.AddCommand(tenantListCmd)
+	return tenantListCmd
 }

--- a/cmd/karavictl/cmd/tenant_list_test.go
+++ b/cmd/karavictl/cmd/tenant_list_test.go
@@ -48,9 +48,10 @@ func TestTenantList(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "list"})
-		rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "list"})
+		cmd.Execute()
 
 		if !gotCalled {
 			t.Error("expected ListTenant to be called, but it wasn't")
@@ -70,9 +71,10 @@ func TestTenantList(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "list"})
-		go rootCmd.Execute()
+		cmd := NewRootCmd()
+		cmd.SetErr(&gotOutput)
+		cmd.SetArgs([]string{"tenant", "list"})
+		go cmd.Execute()
 		<-done
 
 		wantCode := 1
@@ -106,7 +108,10 @@ func TestTenantList(t *testing.T) {
 		}
 		var gotOutput bytes.Buffer
 
-		tenantListCmd.SetErr(&gotOutput)
+		rootCmd := NewRootCmd()
+		//tenantListCmd := NewTenantListCmd()
+
+		rootCmd.SetErr(&gotOutput)
 		rootCmd.SetArgs([]string{"tenant", "list"})
 
 		go rootCmd.Execute()

--- a/cmd/karavictl/cmd/tenant_revoke.go
+++ b/cmd/karavictl/cmd/tenant_revoke.go
@@ -22,60 +22,58 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tenantRevokeCmd represents the revoke command
-var tenantRevokeCmd = &cobra.Command{
-	Use:   "revoke",
-	Short: "Revoke tenant access to Karavi Authorization.",
-	Long:  `Revokes tenant access to Karavi Authorization.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cmd.Flags().GetString("addr")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+// NewTenantRevokeCmd creates a new revoke command
+func NewTenantRevokeCmd() *cobra.Command {
+	tenantRevokeCmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke tenant access to Karavi Authorization.",
+		Long:  `Revokes tenant access to Karavi Authorization.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := cmd.Flags().GetString("addr")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		insecure, err := cmd.Flags().GetBool("insecure")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			insecure, err := cmd.Flags().GetBool("insecure")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		defer conn.Close()
+			tenantClient, conn, err := CreateTenantServiceClient(addr, insecure)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			defer conn.Close()
 
-		tenantName, err := cmd.Flags().GetString("name")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-		isCancel, err := cmd.Flags().GetBool("cancel")
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			tenantName, err := cmd.Flags().GetString("name")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+			isCancel, err := cmd.Flags().GetBool("cancel")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		var resp interface{}
-		switch {
-		case isCancel:
-			resp, err = tenantClient.CancelRevokeTenant(context.Background(), &pb.CancelRevokeTenantRequest{
-				TenantName: tenantName,
-			})
-		default:
-			resp, err = tenantClient.RevokeTenant(context.Background(), &pb.RevokeTenantRequest{
-				TenantName: tenantName,
-			})
-		}
-		if err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
+			var resp interface{}
+			switch {
+			case isCancel:
+				resp, err = tenantClient.CancelRevokeTenant(context.Background(), &pb.CancelRevokeTenantRequest{
+					TenantName: tenantName,
+				})
+			default:
+				resp, err = tenantClient.RevokeTenant(context.Background(), &pb.RevokeTenantRequest{
+					TenantName: tenantName,
+				})
+			}
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
 
-		if err := JSONOutput(cmd.OutOrStdout(), &resp); err != nil {
-			reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
-		}
-	},
-}
-
-func init() {
-	tenantCmd.AddCommand(tenantRevokeCmd)
+			if err := JSONOutput(cmd.OutOrStdout(), &resp); err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+			}
+		},
+	}
 
 	tenantRevokeCmd.Flags().StringP("name", "n", "", "Tenant name")
 	err := tenantRevokeCmd.MarkFlagRequired("name")
@@ -83,4 +81,5 @@ func init() {
 		reportErrorAndExit(JSONOutput, os.Stderr, err)
 	}
 	tenantRevokeCmd.Flags().BoolP("cancel", "c", false, "Cancel a previous tenant revocation")
+	return tenantRevokeCmd
 }

--- a/cmd/karavictl/main.go
+++ b/cmd/karavictl/main.go
@@ -16,6 +16,8 @@ package main
 
 import "karavi-authorization/cmd/karavictl/cmd"
 
+var rootCmd = cmd.NewRootCmd()
+
 func main() {
-	cmd.Execute()
+	rootCmd.Execute()
 }

--- a/cmd/karavictl/main.go
+++ b/cmd/karavictl/main.go
@@ -14,8 +14,15 @@
 
 package main
 
-import "karavi-authorization/cmd/karavictl/cmd"
+import (
+	"fmt"
+	"karavi-authorization/cmd/karavictl/cmd"
+	"os"
+)
 
 func main() {
-	cmd.NewRootCmd().Execute()
+	if err := cmd.NewRootCmd().Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/karavictl/main.go
+++ b/cmd/karavictl/main.go
@@ -16,8 +16,6 @@ package main
 
 import "karavi-authorization/cmd/karavictl/cmd"
 
-var rootCmd = cmd.NewRootCmd()
-
 func main() {
-	rootCmd.Execute()
+	cmd.NewRootCmd().Execute()
 }


### PR DESCRIPTION
# Description

This PR adds support for creating a role for a PowerMax system.

This also fixes an issue if you create PowerMax storage and then Powerflex storage, the PowerMax systems would be listed under PowerFlex storage.

To validate a PowerMax role, we verify that the system ID exists as an authorized storage system and verify that the specified Storage Resrouce Pool exists on the PowerMax.

The cobra commands have been refactored in favor of contstructors rather than global variables. This fixes an issue in test runs where we want to update/set various flags on the commands.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #83      |

# Checklist:

- [x] I have performed a self-review of my own changes.

```
# make test
docker run --rm -it -v /git/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
data.karavi.authz.url.test_get_api_login_allowed: PASS (1.792405ms)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (711.846µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (1.538507ms)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (1.241773ms)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (944.188µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (880.791µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (829.917µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (1.043505ms)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (946.403µs)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (762.907µs)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (5.866155ms)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (628.847µs)
data.karavi.volumes.create.test_small_request_allowed: PASS (2.035073ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (375.062µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  5.433s  coverage: 60.9% of statements
ok      karavi-authorization/cmd/proxy-server   0.061s  coverage: 0.7% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
?       karavi-authorization/cmd/tenant-service [no test files]
ok      karavi-authorization/deploy     0.101s  coverage: 84.6% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.125s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     6.454s  coverage: 68.0% of statements
ok      karavi-authorization/internal/quota     0.514s  coverage: 92.6% of statements
ok      karavi-authorization/internal/roles     0.076s  coverage: 96.0% of statements
ok      karavi-authorization/internal/tenantsvc 3.907s  coverage: 82.9% of statements
ok      karavi-authorization/internal/token     0.045s  coverage: 90.0% of statements
ok      karavi-authorization/internal/web       0.034s  coverage: 24.1% of statements
?       karavi-authorization/pb [no test files]
```