### PR TITLE
Provide human-readable quota size when creating/updating a role using karavictl

### DIFF
--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -53,7 +53,11 @@ func NewRoleCreateCmd() *cobra.Command {
 				if len(t) < roleFlagSize {
 					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, errors.New("role does not have enough arguments")))
 				}
-				err = rff.Add(roles.NewInstance(t[0], t[1:]...))
+				newRole, err := roles.NewInstance(t[0], t[1:]...)
+				if err != nil {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
+				}
+				err = rff.Add(newRole)
 				if err != nil {
 					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 				}

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -109,6 +109,9 @@ func Test_Unit_RoleCreate(t *testing.T) {
 		"success creating role with json file": func(*testing.T) (string, int) {
 			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=9GB", 0
 		},
+		"failure creating role with negative quota": func(*testing.T) (string, int) {
+			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=-2GB", 1
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -186,6 +189,9 @@ func Test_Unit_RoleCreate_PowerMax(t *testing.T) {
 	tests := map[string]func(t *testing.T) (string, int){
 		"success creating role with json file": func(*testing.T) (string, int) {
 			return "--role=NewRole3=powermax=000197900714=bronze=9GB", 0
+		},
+		"failure creating role with negative quota": func(*testing.T) (string, int) {
+			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=-2GB", 1
 		},
 	}
 	for name, tc := range tests {

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -107,10 +107,7 @@ func Test_Unit_RoleCreate(t *testing.T) {
 
 	tests := map[string]func(t *testing.T) (string, int){
 		"success creating role with json file": func(*testing.T) (string, int) {
-			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=9000000", 0
-		},
-		"failure creating role with negative quota": func(*testing.T) (string, int) {
-			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=-2", 1
+			return "--role=NewRole1=powerflex=542a2d5f5122210f=bronze=9GB", 0
 		},
 	}
 	for name, tc := range tests {
@@ -188,10 +185,7 @@ func Test_Unit_RoleCreate_PowerMax(t *testing.T) {
 
 	tests := map[string]func(t *testing.T) (string, int){
 		"success creating role with json file": func(*testing.T) (string, int) {
-			return "--role=NewRole3=powermax=000197900714=bronze=9000000", 0
-		},
-		"failure creating role with negative quota": func(*testing.T) (string, int) {
-			return "--role=NewRole4=powermax=000197900714=bronze=-2", 1
+			return "--role=NewRole3=powermax=000197900714=bronze=9GB", 0
 		},
 	}
 	for name, tc := range tests {

--- a/cmd/karavictl/cmd/role_delete.go
+++ b/cmd/karavictl/cmd/role_delete.go
@@ -47,7 +47,10 @@ func NewRoleDeleteCmd() *cobra.Command {
 			matched := make(map[roles.Instance]struct{})
 			for _, v := range roleFlags {
 				t := strings.Split(v, "=")
-				r := roles.NewInstance(t[0], t[1:]...)
+				r, err := roles.NewInstance(t[0], t[1:]...)
+				if err != nil {
+					continue
+				}
 				existing.Select(func(e roles.Instance) {
 					if strings.Contains(e.RoleKey.String(), r.RoleKey.String()) {
 						matched[e] = struct{}{}

--- a/cmd/karavictl/cmd/role_delete.go
+++ b/cmd/karavictl/cmd/role_delete.go
@@ -49,7 +49,7 @@ func NewRoleDeleteCmd() *cobra.Command {
 				t := strings.Split(v, "=")
 				r, err := roles.NewInstance(t[0], t[1:]...)
 				if err != nil {
-					continue
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("invalid attributes for role %s", t[0]))
 				}
 				existing.Select(func(e roles.Instance) {
 					if strings.Contains(e.RoleKey.String(), r.RoleKey.String()) {

--- a/cmd/karavictl/cmd/role_list.go
+++ b/cmd/karavictl/cmd/role_list.go
@@ -15,10 +15,27 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"karavi-authorization/internal/roles"
 
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
+	"github.com/valyala/fastjson"
 )
+
+// ReadableInstance embeds a RoleKey and adds additional data, e.g. the
+// quota.
+type ReadableInstance struct {
+	Role  roles.RoleKey
+	Quota string
+}
+
+// ReadableJSON is the outer wrapper for performing JSON operations
+// on a collection of role instances.
+type ReadableJSON struct {
+	m map[roles.RoleKey]*ReadableInstance
+}
 
 // NewRoleListCmd creates a new role list command
 func NewRoleListCmd() *cobra.Command {
@@ -27,16 +44,128 @@ func NewRoleListCmd() *cobra.Command {
 		Short: "List roles",
 		Long:  `List roles`,
 		Run: func(cmd *cobra.Command, args []string) {
-			roles, err := GetRoles()
+			rolesmap, err := GetRoles()
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to list roles: %v", err))
 			}
 
-			err = JSONOutput(cmd.OutOrStdout(), &roles)
+			readRole := transformReadable(rolesmap)
+			err = JSONOutput(cmd.OutOrStdout(), &readRole)
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("unable to format json output: %v", err))
 			}
 		},
 	}
 	return roleListCmd
+}
+
+func transformReadable(rolesmap *roles.JSON) *ReadableJSON {
+
+	readableroles := &ReadableJSON{}
+
+	if readableroles.m == nil {
+		readableroles.m = make(map[roles.RoleKey]*ReadableInstance)
+	}
+
+	for k, v := range rolesmap.M {
+		ins := &ReadableInstance{
+			Role: k,
+		}
+		ins.Quota = humanize.Bytes(uint64(v.Quota))
+		ins.Role = v.RoleKey
+		readableroles.m[k] = ins
+	}
+
+	return readableroles
+}
+
+// MarshalJSON marshals the JSON value into JSON.
+// It adds extra maps around each type of data to
+// help describe it.
+func (j *ReadableJSON) MarshalJSON() ([]byte, error) {
+
+	m := make(map[string]interface{})
+
+	initMap := func(m interface{}, key string) map[string]interface{} {
+		t := m.(map[string]interface{})
+		if _, ok := t[key]; !ok {
+			t[key] = make(map[string]interface{})
+		}
+		ret := t[key].(map[string]interface{})
+		return ret
+	}
+
+	for k, v := range j.m {
+		// role names
+		if _, ok := m[k.Name]; !ok {
+			m[k.Name] = make(map[string]interface{})
+		}
+		// system types
+		st := initMap(m[k.Name], "system_types")
+		if _, ok := st[k.SystemType]; !ok {
+			st[k.SystemType] = make(map[string]interface{})
+		}
+		// system ids
+		sid := initMap(st[k.SystemType], "system_ids")
+		if _, ok := sid[k.SystemID]; !ok {
+			sid[k.SystemID] = make(map[string]interface{})
+		}
+		// pools
+		p := initMap(sid[k.SystemID], "pool_quotas")
+		if _, ok := p[k.Pool]; !ok {
+			p[k.Pool] = make(map[string]interface{})
+		}
+		// pool quotas
+		p[k.Pool] = v.Quota
+	}
+
+	return json.Marshal(&m)
+}
+
+// UnmarshalJSON unmarshals the given bytes into this
+// JSON value.
+func (j *ReadableJSON) UnmarshalJSON(b []byte) error {
+
+	if j.m == nil {
+		j.m = make(map[roles.RoleKey]*ReadableInstance)
+	}
+	var p fastjson.Parser
+
+	v, err := p.ParseBytes(b)
+	if err != nil {
+		return err
+	}
+	o, err := v.Object()
+	if err != nil {
+		return err
+	}
+
+	o.Visit(func(k1 []byte, v1 *fastjson.Value) {
+		// k1 = name
+		v1.GetObject("system_types").Visit(func(k2 []byte, v2 *fastjson.Value) {
+			// k2 = system type
+			v2.GetObject("system_ids").Visit(func(k3 []byte, v3 *fastjson.Value) {
+				// k3 = system id
+				v3.GetObject("pool_quotas").Visit(func(k4 []byte, v4 *fastjson.Value) {
+					//n, err := v4.Int()
+					if err != nil {
+						return
+					}
+					r := ReadableInstance{
+						Role: roles.RoleKey{
+							Name:       string(k1),
+							SystemType: string(k2),
+							SystemID:   string(k3),
+							Pool:       string(k4),
+						},
+
+						Quota: v4.String(),
+					}
+					j.m[r.Role] = &r
+				})
+			})
+		})
+	})
+
+	return nil
 }

--- a/cmd/karavictl/cmd/role_list.go
+++ b/cmd/karavictl/cmd/role_list.go
@@ -71,7 +71,8 @@ func transformReadable(rolesmap *roles.JSON) *ReadableJSON {
 		ins := &ReadableInstance{
 			Role: k,
 		}
-		ins.Quota = humanize.Bytes(uint64(v.Quota))
+		// quota is stored as kilobytes, so convert back to bytes before returning
+		ins.Quota = humanize.Bytes(uint64(v.Quota) * 1000)
 		ins.Role = v.RoleKey
 		readableroles.m[k] = ins
 	}

--- a/cmd/karavictl/cmd/role_list_test.go
+++ b/cmd/karavictl/cmd/role_list_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+const ExpectedInstanceCount = 3
 
 func Test_Unit_RoleList(t *testing.T) {
 
@@ -71,4 +74,65 @@ func Test_Unit_RoleList(t *testing.T) {
 			assert.Equal(t, expectedRoleQuotas, numberOfStdoutNewlines)
 		})
 	}
+}
+
+func TestReadableJSON_MarshalJSON(t *testing.T) {
+	sut := buildJSON(t)
+
+	_, err := json.Marshal(&sut)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestJSON_Unmarshal(t *testing.T) {
+	sut := buildJSON(t)
+
+	got := len(sut.m)
+
+	want := ExpectedInstanceCount
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func buildJSON(t *testing.T) *ReadableJSON {
+	payload := `
+{
+  "OpenShiftMongo": {
+    "system_types": {
+      "powerflex": {
+        "system_ids": {
+          "542a2d5f5122210f": {
+            "pool_quotas": {
+              "bronze": "4 GB",
+			  "silver": "8 GB"
+            }
+          }
+        }
+      }
+    }
+  },
+  "OpenShiftMongo-large": {
+    "system_types": {
+      "powerflex": {
+        "system_ids": {
+          "542a2d5f5122210f": {
+            "pool_quotas": {
+              "bronze": "4 GB"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+	var sut ReadableJSON
+	err := json.NewDecoder(strings.NewReader(payload)).Decode(&sut)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &sut
 }

--- a/cmd/karavictl/cmd/role_update.go
+++ b/cmd/karavictl/cmd/role_update.go
@@ -44,7 +44,12 @@ func NewRoleUpdateCmd() *cobra.Command {
 
 			for _, v := range roleFlags {
 				t := strings.Split(v, "=")
-				err = rff.Add(roles.NewInstance(t[0], t[1:]...))
+
+				newrole, err := roles.NewInstance(t[0], t[1:]...)
+				if err != nil {
+					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
+				}
+				err = rff.Add(newrole)
 				if err != nil {
 					reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, err))
 				}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dell/gopowermax v1.4.0 // indirect
 	github.com/dell/goscaleio v1.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -84,7 +84,7 @@ func NewJSON() JSON {
 // - parts[1]: system id
 // - parts[2]: pool name
 // - parts[3]: quota
-func NewInstance(role string, parts ...string) *Instance {
+func NewInstance(role string, parts ...string) (*Instance, error) {
 	ins := &Instance{}
 	ins.Name = role
 	for i, v := range parts {
@@ -98,13 +98,13 @@ func NewInstance(role string, parts ...string) *Instance {
 		case 3: // quota
 			n, err := humanize.ParseBytes(v)
 			if err != nil {
-				n = 0
+				return nil, err
 			}
 			ins.Quota = int(n)
 		}
 
 	}
-	return ins
+	return ins, nil
 }
 
 // Get returns an *Instance associated with the given key.

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -96,7 +96,6 @@ func NewInstance(role string, parts ...string) *Instance {
 		case 2: // pool name
 			ins.Pool = v
 		case 3: // quota
-			//n := mustParseInt(strconv.ParseInt(v, 10, 64))
 			n, err := humanize.ParseBytes(v)
 			if err != nil {
 				n = 0

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/dustin/go-humanize"
 	"github.com/valyala/fastjson"
 )
 
@@ -35,6 +35,20 @@ type RoleKey struct {
 	SystemType string
 	SystemID   string
 	Pool       string
+}
+
+// Instance embeds a RoleKey and adds additional data, e.g. the
+// quota.
+type Instance struct {
+	RoleKey
+	Quota int
+}
+
+// JSON is the outer wrapper for performing JSON operations
+// on a collection of role instances.
+type JSON struct {
+	mu sync.Mutex // guards m
+	M  map[RoleKey]*Instance
 }
 
 // String returns the string representation of a RoleKey.
@@ -56,11 +70,11 @@ func (r *RoleKey) String() string {
 	return sb.String()
 }
 
-// Instance embeds a RoleKey and adds additional data, e.g. the
-// quota.
-type Instance struct {
-	RoleKey
-	Quota int
+// NewJSON builds a new JSON value with an allocated map.
+func NewJSON() JSON {
+	return JSON{
+		M: make(map[RoleKey]*Instance),
+	}
 }
 
 // NewInstance builds a new role. Its arguments expect the following
@@ -82,7 +96,11 @@ func NewInstance(role string, parts ...string) *Instance {
 		case 2: // pool name
 			ins.Pool = v
 		case 3: // quota
-			n := mustParseInt(strconv.ParseInt(v, 10, 64))
+			//n := mustParseInt(strconv.ParseInt(v, 10, 64))
+			n, err := humanize.ParseBytes(v)
+			if err != nil {
+				n = 0
+			}
 			ins.Quota = int(n)
 		}
 
@@ -90,26 +108,12 @@ func NewInstance(role string, parts ...string) *Instance {
 	return ins
 }
 
-// JSON is the outer wrapper for performing JSON operations
-// on a collection of role instances.
-type JSON struct {
-	mu sync.Mutex // guards m
-	m  map[RoleKey]*Instance
-}
-
-// NewJSON builds a new JSON value with an allocated map.
-func NewJSON() JSON {
-	return JSON{
-		m: make(map[RoleKey]*Instance),
-	}
-}
-
 // Get returns an *Instance associated with the given key.
 func (j *JSON) Get(k RoleKey) *Instance {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if v, ok := j.m[k]; ok {
+	if v, ok := j.M[k]; ok {
 		return v
 	}
 	return nil
@@ -121,7 +125,7 @@ func (j *JSON) Select(fn func(r Instance)) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	for _, v := range j.m {
+	for _, v := range j.M {
 		fn(*v)
 	}
 }
@@ -132,7 +136,7 @@ func (j *JSON) Instances() []*Instance {
 	defer j.mu.Unlock()
 
 	var ret []*Instance
-	for _, v := range j.m {
+	for _, v := range j.M {
 		ret = append(ret, v)
 	}
 	return ret
@@ -144,14 +148,14 @@ func (j *JSON) Add(v *Instance) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if j.m == nil {
-		j.m = make(map[RoleKey]*Instance)
+	if j.M == nil {
+		j.M = make(map[RoleKey]*Instance)
 	}
-	if _, ok := j.m[v.RoleKey]; ok {
+	if _, ok := j.M[v.RoleKey]; ok {
 		return fmt.Errorf("%q is duplicated", v.RoleKey)
 	}
 
-	j.m[v.RoleKey] = v
+	j.M[v.RoleKey] = v
 
 	return nil
 }
@@ -162,10 +166,10 @@ func (j *JSON) Remove(r *Instance) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if _, ok := j.m[r.RoleKey]; !ok {
+	if _, ok := j.M[r.RoleKey]; !ok {
 		return errors.New("not found")
 	}
-	delete(j.m, r.RoleKey)
+	delete(j.M, r.RoleKey)
 	return nil
 }
 
@@ -187,7 +191,7 @@ func (j *JSON) MarshalJSON() ([]byte, error) {
 		return ret
 	}
 
-	for k, v := range j.m {
+	for k, v := range j.M {
 		// role names
 		if _, ok := m[k.Name]; !ok {
 			m[k.Name] = make(map[string]interface{})
@@ -220,8 +224,8 @@ func (j *JSON) UnmarshalJSON(b []byte) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if j.m == nil {
-		j.m = make(map[RoleKey]*Instance)
+	if j.M == nil {
+		j.M = make(map[RoleKey]*Instance)
 	}
 	var p fastjson.Parser
 
@@ -255,7 +259,7 @@ func (j *JSON) UnmarshalJSON(b []byte) error {
 
 						Quota: n,
 					}
-					j.m[r.RoleKey] = &r
+					j.M[r.RoleKey] = &r
 				})
 			})
 		})

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -96,11 +97,16 @@ func NewInstance(role string, parts ...string) (*Instance, error) {
 		case 2: // pool name
 			ins.Pool = v
 		case 3: // quota
+			// if quota can be converted to an integer, set units to kilobytes
+			if _, err := strconv.Atoi(v); err == nil {
+				v = fmt.Sprintf("%s KB", v)
+			}
 			n, err := humanize.ParseBytes(v)
 			if err != nil {
 				return nil, err
 			}
-			ins.Quota = int(n)
+			// store quota in kilobytes
+			ins.Quota = int(n / 1000)
 		}
 
 	}

--- a/internal/roles/roles_test.go
+++ b/internal/roles/roles_test.go
@@ -114,7 +114,7 @@ func TestNewInstance(t *testing.T) {
 	name := "test"
 	args := []string{"powerflex", "542", "bronze", "100"}
 
-	got := roles.NewInstance(name, args...)
+	got, err := roles.NewInstance(name, args...)
 
 	n, err := strconv.ParseInt(args[3], 10, 64)
 	if err != nil {
@@ -136,10 +136,21 @@ func TestNewInstance(t *testing.T) {
 
 func TestJSON_Instances(t *testing.T) {
 	sut := roles.NewJSON()
-	if err := sut.Add(roles.NewInstance("role-1")); err != nil {
+
+	rr, err := roles.NewInstance("role-1")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := sut.Add(roles.NewInstance("role-2")); err != nil {
+
+	if err := sut.Add(rr); err != nil {
+		t.Fatal(err)
+	}
+	rr2, err := roles.NewInstance("role-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sut.Add(rr2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,7 +246,11 @@ func TestJSON_Remove(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				sut := buildJSON(t)
 
-				err := sut.Remove(roles.NewInstance(tt.givenArgs[0], tt.givenArgs[1:]...))
+				rr, err := roles.NewInstance(tt.givenArgs[0], tt.givenArgs[1:]...)
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = sut.Remove(rr)
 
 				if tt.expectErr && err == nil {
 					t.Errorf("err: got %+v, want %+v", nil, true)
@@ -247,10 +262,15 @@ func TestJSON_Remove(t *testing.T) {
 		sut := buildJSON(t)
 		c := len(sut.Instances())
 
-		err := sut.Remove(roles.NewInstance("OpenShiftMongo",
+		rr, err := roles.NewInstance("OpenShiftMongo",
 			"powerflex",
 			"542a2d5f5122210f",
-			"bronze"))
+			"bronze")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sut.Remove(rr)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
# Description

Provide human-readable quota size when creating/updating a role using karavictl
Allow quota to be provided as a human-readable string (eg. 100G) when creating or updating a role

[]# karavictl storage create --endpoint https://1.1.1.1 --insecure --system-id xxxxxxxxx --type powerflex --user xxxxx --password xxxxxx
[]# karavictl role create --role=TestRole1=powerflex=xxxxxxx=mypool=42GB
[]# karavictl role list
{
  "TestRole1": {
    "system_types": {
      "powerflex": {
        "system_ids": {
          "xxxxxxx": {
            "pool_quotas": {
              "mypool": "42 GB"
            }
          }
        }
      }
    }
  }
}

[root@] karavi-authorization]# make test
docker run --rm -it -v /root/IOAD/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
data.karavi.authz.url.test_get_api_login_allowed: PASS (3.033074ms)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (634.739µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (590.042µs)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (447.202µs)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (399.29µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (417.211µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (383.684µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (404.416µs)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (371.584µs)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (390.076µs)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (376.48µs)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (377.489µs)
data.karavi.volumes.create.test_small_request_allowed: PASS (1.480503ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (311.946µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  4.254s  coverage: 61.6% of statements
ok      karavi-authorization/cmd/proxy-server   0.047s  coverage: 0.7% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
?       karavi-authorization/cmd/tenant-service [no test files]
ok      karavi-authorization/deploy     0.082s  coverage: 84.6% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.127s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     6.399s  coverage: 68.0% of statements
ok      karavi-authorization/internal/quota     0.344s  coverage: 92.6% of statements
ok      karavi-authorization/internal/roles     0.046s  coverage: 93.1% of statements
ok      karavi-authorization/internal/tenantsvc 1.511s  coverage: 82.9% of statements
ok      karavi-authorization/internal/token     0.034s  coverage: 90.0% of statements
ok      karavi-authorization/internal/web       0.043s  coverage: 24.1% of statements
?       karavi-authorization/pb [no test files]

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #87      |

# Checklist:

- [x] I have performed a self-review of my own changes.