### PR TITLE
Retry on sidecar-proxy ListenAndServeTLS

### DIFF
--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -131,6 +131,7 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 	var retryListenAndServeTLS func(int) error
 	retryListenAndServeTLS = func(port int) error {
 		listenAddr := fmt.Sprintf(":%v", strconv.Itoa(port))
+		pi.log.Printf("Listening on %s", listenAddr)
 		pi.svr = &http.Server{
 			Addr:      listenAddr,
 			Handler:   pi.Handler(proxyURL, access, refresh),

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -138,9 +138,9 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 		}
 
 		if err := pi.svr.ListenAndServeTLS("", ""); err != nil {
-			var optErr *net.OpError
-			if errors.As(err, &optErr) {
-				if optErr.Op == "listen" && strings.Contains(optErr.Error(), "address already in use") {
+			var opErr *net.OpError
+			if errors.As(err, &opErr) {
+				if opErr.Op == "listen" && strings.Contains(opErr.Error(), "address already in use") {
 					pi.log.Printf("Failed...trying another port")
 					return retryListenAndServeTLS(port + 1)
 				}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -131,7 +131,6 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 	var retryListenAndServeTLS func(int) error
 	retryListenAndServeTLS = func(port int) error {
 		listenAddr := fmt.Sprintf(":%v", strconv.Itoa(port))
-		pi.log.Printf("Listening on %s", listenAddr)
 		pi.svr = &http.Server{
 			Addr:      listenAddr,
 			Handler:   pi.Handler(proxyURL, access, refresh),
@@ -142,6 +141,7 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 			var optErr *net.OpError
 			if errors.As(err, &optErr) {
 				if optErr.Op == "listen" && strings.Contains(optErr.Error(), "address already in use") {
+					pi.log.Printf("Failed...trying another port")
 					return retryListenAndServeTLS(port + 1)
 				}
 			}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -150,7 +150,6 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 		}
 		return nil
 	}
-
 	return retryListenAndServeTLS(portNum)
 }
 


### PR DESCRIPTION
# Description

This PR enables the sidecar-proxy to incrementally retry ports to listen and serve on incase a port is already in use.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #89     |

# Checklist:

- [x] I have performed a self-review of my own changes.

This was tested by manually deploying and injecting the csi-powerflex driver and then manually deploying and injecting the csi-powermax driver successfully.

```
# make test
docker run --rm -it -v /git/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
data.karavi.authz.url.test_get_api_login_allowed: PASS (1.665811ms)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (557.628µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (517.168µs)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (1.4634ms)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (907.535µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (836.368µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (841.543µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (927.712µs)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (844.29µs)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (8.601869ms)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (503.726µs)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (548.399µs)
data.karavi.volumes.create.test_small_request_allowed: PASS (2.068174ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (274.374µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  5.742s  coverage: 60.8% of statements
ok      karavi-authorization/cmd/proxy-server   0.058s  coverage: 0.7% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
?       karavi-authorization/cmd/tenant-service [no test files]
ok      karavi-authorization/deploy     0.089s  coverage: 84.6% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.088s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     6.403s  coverage: 68.0% of statements
ok      karavi-authorization/internal/quota     0.439s  coverage: 92.6% of statements
ok      karavi-authorization/internal/roles     0.040s  coverage: 96.0% of statements
ok      karavi-authorization/internal/tenantsvc 1.743s  coverage: 82.9% of statements
ok      karavi-authorization/internal/token     0.039s  coverage: 90.0% of statements
ok      karavi-authorization/internal/web       0.047s  coverage: 24.1% of statements
?       karavi-authorization/pb [no test files]
```