### PR TITLE
powermax storage update handler no longer prints full info

### DIFF
--- a/internal/proxy/powermax_handler.go
+++ b/internal/proxy/powermax_handler.go
@@ -109,8 +109,8 @@ func (h *PowerMaxHandler) UpdateSystems(ctx context.Context, r io.Reader) error 
 		}
 	}
 
-	for _, id := range powerMaxSystems {
-		h.log.Printf("Updated systems: %+v", id)
+	for k := range powerMaxSystems {
+		h.log.Printf("Updated systems: %+v", k)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Instead of printing the full powermax system struct to the logs when an update occurs, just print the name of the powermax system. This prevents credentials from accidentally getting logged.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    closes #99      |

# Checklist:

- [x] I have performed a self-review of my own changes.

# Logs:
```
k3s kubectl logs -f -n karavi proxy-server-57f87f8c89-bfmfv proxy-server
time="2021-05-18T21:06:29Z" level=info msg="Config: {Version: Zipkin:{CollectorURI:http://[REDACTED]/api/v2/spans ServiceName:proxy-server Probability:1} Certificate:{CrtFile: K
eyFile: RootCertificate:} Proxy:{Host::8080 ReadTimeout:30s WriteTimeout:30s} Web:{ShowDebugHTTP:false DebugHost::9090 ShutdownTimeout:15s SidecarProxyAddr:dellemc/csm-authorization-sidecar:
v0.2.0 JWTSigningSecret:secret} Database:{Host:redis.karavi.svc.cluster.local:6379 Password:} OpenPolicyAgent:{Host:localhost:8181}}"
time="2021-05-18T21:06:29Z" level=info msg="main: started application version \"develop\""
time="2021-05-18T21:06:29Z" level=info msg="main: initializing otel/zipkin tracing support"
time="2021-05-18T21:06:29Z" level=info msg="main: initializing debugging support"
time="2021-05-18T21:06:29Z" level=info msg="main: debug listening :9090"
time="2021-05-18T21:06:29Z" level=info msg="main: initializing proxy service"
time="2021-05-18T21:06:29Z" level=info msg="main: proxy listening on :8080"
time="2021-05-18T21:08:52Z" level=info msg="Changed! CREATE, /etc/karavi-authorization/storage/..2021_05_18_21_08_52.330258609"
time="2021-05-18T21:08:52Z" level=info msg="Updated systems: 000197901503"
time="2021-05-18T21:08:52Z" level=info msg="Updated systems: 000197901503"
```
The last line in this log used to print out the credentials of the system as seen in #99 but now it prints only the system ID.