### PR TITLE
Added powerscale storage to karavictl

### DIFF
--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"syscall"
 
+	pscale "github.com/dell/goisilon"
 	pmax "github.com/dell/gopowermax"
 	"github.com/dell/gopowermax/types/v90"
 	"github.com/dell/goscaleio"
@@ -34,8 +35,9 @@ import (
 )
 
 const (
-	powerflex = "powerflex"
-	powermax  = "powermax"
+	powerflex  = "powerflex"
+	powermax   = "powermax"
+	powerscale = "powerscale"
 )
 
 // Storage represents a map of storage system types.
@@ -63,8 +65,9 @@ func (id SystemID) String() string {
 }
 
 var supportedStorageTypes = map[string]struct{}{
-	powerflex: {},
-	powermax:  {},
+	powerflex:  {},
+	powermax:   {},
+	powerscale: {},
 }
 
 // NewStorageCreateCmd creates a new create command
@@ -106,19 +109,19 @@ func NewStorageCreateCmd() *cobra.Command {
 
 			// Gather the inputs
 			var input = struct {
-				Type     string
-				Endpoint string
-				SystemID string
-				User     string
-				Password string
-				Insecure bool
+				Type        string
+				Endpoint    string
+				SystemID    string
+				User        string
+				Password    string
+				Insecure    bool
 			}{
-				Type:     verifyInput("type"),
-				Endpoint: verifyInput("endpoint"),
-				SystemID: flagStringValue(cmd.Flags().GetString("system-id")),
-				User:     verifyInput("user"),
-				Password: flagStringValue(cmd.Flags().GetString("password")),
-				Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
+				Type:        verifyInput("type"),
+				Endpoint:    verifyInput("endpoint"),
+				SystemID:    flagStringValue(cmd.Flags().GetString("system-id")),
+				User:        verifyInput("user"),
+				Password:    flagStringValue(cmd.Flags().GetString("password")),
+				Insecure:    flagBoolValue(cmd.Flags().GetBool("insecure")),
 			}
 
 			// Parse the URL and prepare for a password prompt.
@@ -302,6 +305,34 @@ func NewStorageCreateCmd() *cobra.Command {
 						}
 					}
 					createStorageFunc(storageID)
+				}
+
+			case powerscale:
+				tempStorage = storage[powerscale]
+				if tempStorage == nil {
+					tempStorage = make(map[string]System)
+				}
+
+                psClient, err := pscale.NewClientWithArgs(context.Background(), epURL.String() + ":8080", input.Insecure, 1, input.User, "Administrators", input.Password, "")
+				if err != nil {
+					errAndExit(err)
+				}
+
+				clusterConfig, err := psClient.GetClusterConfig(context.Background())
+				if err != nil {
+					errAndExit(err)
+				}
+
+				if clusterConfig.Name != input.SystemID {
+					fmt.Fprintf(cmd.ErrOrStderr(), "cluster name %q not found", input.SystemID)
+					osExit(1)
+				}
+
+				tempStorage[input.SystemID] = System{
+					User:     input.User,
+					Password: input.Password,
+					Endpoint: input.Endpoint,
+					Insecure: input.Insecure,
 				}
 
 			default:

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -109,19 +109,19 @@ func NewStorageCreateCmd() *cobra.Command {
 
 			// Gather the inputs
 			var input = struct {
-				Type        string
-				Endpoint    string
-				SystemID    string
-				User        string
-				Password    string
-				Insecure    bool
+				Type     string
+				Endpoint string
+				SystemID string
+				User     string
+				Password string
+				Insecure bool
 			}{
-				Type:        verifyInput("type"),
-				Endpoint:    verifyInput("endpoint"),
-				SystemID:    flagStringValue(cmd.Flags().GetString("system-id")),
-				User:        verifyInput("user"),
-				Password:    flagStringValue(cmd.Flags().GetString("password")),
-				Insecure:    flagBoolValue(cmd.Flags().GetBool("insecure")),
+				Type:     verifyInput("type"),
+				Endpoint: verifyInput("endpoint"),
+				SystemID: flagStringValue(cmd.Flags().GetString("system-id")),
+				User:     verifyInput("user"),
+				Password: flagStringValue(cmd.Flags().GetString("password")),
+				Insecure: flagBoolValue(cmd.Flags().GetBool("insecure")),
 			}
 
 			// Parse the URL and prepare for a password prompt.
@@ -313,7 +313,7 @@ func NewStorageCreateCmd() *cobra.Command {
 					tempStorage = make(map[string]System)
 				}
 
-                psClient, err := pscale.NewClientWithArgs(context.Background(), epURL.String(), input.Insecure, 1, input.User, "Administrators", input.Password, "")
+				psClient, err := pscale.NewClientWithArgs(context.Background(), epURL.String(), input.Insecure, 1, input.User, "Administrators", input.Password, "")
 				if err != nil {
 					errAndExit(err)
 				}

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -313,7 +313,7 @@ func NewStorageCreateCmd() *cobra.Command {
 					tempStorage = make(map[string]System)
 				}
 
-                psClient, err := pscale.NewClientWithArgs(context.Background(), epURL.String() + ":8080", input.Insecure, 1, input.User, "Administrators", input.Password, "")
+                psClient, err := pscale.NewClientWithArgs(context.Background(), epURL.String(), input.Insecure, 1, input.User, "Administrators", input.Password, "")
 				if err != nil {
 					errAndExit(err)
 				}

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -235,7 +235,7 @@ func TestStorageCreateCmd(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/onefs_api_types_System_instances_testing.json"
 		cmd := NewStorageCreateCmd()
 		setDefaultStorageFlags(t, cmd)
-        setFlag(t, cmd, "system-id", "abcd1234")
+		setFlag(t, cmd, "system-id", "abcd1234")
 		setFlag(t, cmd, "endpoint", ofsts.URL)
 		setFlag(t, cmd, "type", "powerscale")
 		cmd.Run(cmd, nil)

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -183,9 +183,9 @@ func TestStorageCreateCmd(t *testing.T) {
 	ofsts := httptest.NewTLSServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
-			case "/platform/latest":
+			case "/platform/latest/":
 				fmt.Fprintf(w, `{ "latest": "6"}`)
-			case "/platform/3/cluster/config":
+			case "/platform/3/cluster/config/":
 				b, err := ioutil.ReadFile(systemInstancesTestDataPath)
 				if err != nil {
 					t.Error(err)
@@ -235,6 +235,7 @@ func TestStorageCreateCmd(t *testing.T) {
 		systemInstancesTestDataPath = "testdata/onefs_api_types_System_instances_testing.json"
 		cmd := NewStorageCreateCmd()
 		setDefaultStorageFlags(t, cmd)
+        setFlag(t, cmd, "system-id", "abcd1234")
 		setFlag(t, cmd, "endpoint", ofsts.URL)
 		setFlag(t, cmd, "type", "powerscale")
 		cmd.Run(cmd, nil)

--- a/cmd/karavictl/cmd/testdata/onefs_api_types_System_instances_testing.json
+++ b/cmd/karavictl/cmd/testdata/onefs_api_types_System_instances_testing.json
@@ -1,0 +1,50 @@
+{
+                "description": "Isilon cluster used by Ansible team for development and testing",
+                "devices": [
+                    {
+                        "devid": 1,
+                        "guid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1",
+                        "is_up": true,
+                        "lnn": 1
+                    },
+                    {
+                        "devid": 2,
+                        "guid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2",
+                        "is_up": true,
+                        "lnn": 2
+                    },
+                    {
+                        "devid": 3,
+                        "guid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx3",
+                        "is_up": true,
+                        "lnn": 3
+                    }
+                ],
+                "encoding": "utf-8",
+                "guid": "abcabcabcabcabcabcabcabcabcabcabcabc",
+                "has_quorum": true,
+                "is_compliance": false,
+                "is_virtual": false,
+                "is_vonefs": false,
+                "join_mode": "Manual",
+                "local_devid": 1,
+                "local_lnn": 1,
+                "local_serial": "XXXXX-XXXXXX-XXXX",
+                "name": "abcd1234",
+                "onefs_version": {
+                    "build": "B_8_1_3_013(RELEASE)",
+                    "copyright": "Copyright (c) 2001-2019 EMC Corporation. All Rights Reserved.",
+                    "reldate": 1100006,
+                    "release": "v8.1.3.0",
+                    "revision": "576745869412401165",
+                    "type": "Isilon OneFS",
+                    "version": "Isilon OneFS v8.1.3.0 B_8_1_3_013(RELEASE): 0x80103500000000D:Mon Jan  7 12:10:23 PST 2019    root@sea-build10-03:/b/mnt/obj/b/mnt/src/sys/IQ.amd64.release   FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610"
+                },
+                "timezone": {
+                    "abbreviation": "UTC",
+                    "custom": "",
+                    "name": "Greenwich Mean Time",
+                    "path": "GMT"
+                },
+                "upgrade_type": null
+            }

--- a/cmd/karavictl/cmd/testdata/onefs_api_types_System_instances_testing.json
+++ b/cmd/karavictl/cmd/testdata/onefs_api_types_System_instances_testing.json
@@ -32,13 +32,13 @@
                 "local_serial": "XXXXX-XXXXXX-XXXX",
                 "name": "abcd1234",
                 "onefs_version": {
-                    "build": "B_8_1_3_013(RELEASE)",
+                    "build": "A_B_C_D_123(RELEASE)",
                     "copyright": "Copyright (c) 2001-2019 EMC Corporation. All Rights Reserved.",
-                    "reldate": 1100006,
-                    "release": "v8.1.3.0",
-                    "revision": "576745869412401165",
+                    "reldate": 1111111,
+                    "release": "v9.9.9.9",
+                    "revision": "123123123123123123",
                     "type": "Isilon OneFS",
-                    "version": "Isilon OneFS v8.1.3.0 B_8_1_3_013(RELEASE): 0x80103500000000D:Mon Jan  7 12:10:23 PST 2019    root@sea-build10-03:/b/mnt/obj/b/mnt/src/sys/IQ.amd64.release   FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610"
+                    "version": "Isilon OneFS"
                 },
                 "timezone": {
                     "abbreviation": "UTC",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/alicebob/miniredis/v2 v2.14.3
+	github.com/dell/goisilon v1.4.0 // indirect
 	github.com/dell/gopowermax v1.4.0
 	github.com/dell/goscaleio v1.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/akutz/gournal v0.5.0 h1:ELlKqTTp9dmaaadDvO19YxUmdMghYuSi23AxoSL/g98=
+github.com/akutz/gournal v0.5.0/go.mod h1:w7Ucz8IOvtgsEL1321IY8bIUoASU/khBjAy/L6doMWc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -131,6 +133,8 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 h1:sgNeV1VRMDzs6rzyPpxyM0jp317hnwiq58Filgag2xw=
 github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0/go.mod h1:J70FGZSbzsjecRTiTzER+3f1KZLNaXkuv+yeFTKoxM8=
+github.com/dell/goisilon v1.4.0 h1:1zktsa0RrUzXv98/DUnU1vU6f58M/xcMr4slx+V1bPY=
+github.com/dell/goisilon v1.4.0/go.mod h1:FnAVgQNR6ijG888MC9TlWV2t8IazURs4WM73ZNBQaSI=
 github.com/dell/gopowermax v1.4.0 h1:o54Gk2xOuK9DHJK+tZNDusc650qQuFGvTqjNaAvEJBw=
 github.com/dell/gopowermax v1.4.0/go.mod h1:PCssc1Twr0sfXX48P9ayFTa/vl17xzORHDu1ElUaCe0=
 github.com/dell/goscaleio v1.2.0 h1:97x2rM0cRlBhy3povQe1OhxF4uI9vCgjRb/o19nP2d0=


### PR DESCRIPTION
# Description

Adds support for adding PowerScale as a storage system with karavictl

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #107      |

# Checklist:

- [x] I have performed a self-review of my own changes.
```
$ ./bin/karavictl storage create --endpoint https://<OneFS IP> --insecure --system-id purpsefully-wrong --type powerscale --user admin --password <OMITTED>
cluster name "purpsefully-wrong" not found
$ ./bin/karavictl storage create --endpoint https://<OneFS IP> --insecure --system-id <system-id> --type powerscale --user admin --password <OMITTED>
$ ./bin/karavictl storage list
{
  "storage": {
    "powermax": {},
    "powerscale": {
      "lglw6195": {
        "Endpoint": "https://<ip-address>",
        "Insecure": true,
        "Password": "(omitted)",
        "User": "admin"
      }
    }
  }
}
```