### PR TITLE
Removing jwt-go from mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,9 @@ go 1.16
 
 require (
 	github.com/alicebob/miniredis/v2 v2.14.3
-	github.com/dell/goisilon v1.4.0 // indirect
+	github.com/dell/goisilon v1.4.0
 	github.com/dell/gopowermax v1.4.0
 	github.com/dell/goscaleio v1.2.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/dell/gopowermax v1.4.0/go.mod h1:PCssc1Twr0sfXX48P9ayFTa/vl17xzORHDu1
 github.com/dell/goscaleio v1.2.0 h1:97x2rM0cRlBhy3povQe1OhxF4uI9vCgjRb/o19nP2d0=
 github.com/dell/goscaleio v1.2.0/go.mod h1:xrLhA17HgAXG616N7jQOatzVuxeZ5rfYsGSUBaQ7U8I=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,7 @@ github.com/dell/gopowermax v1.4.0/go.mod h1:PCssc1Twr0sfXX48P9ayFTa/vl17xzORHDu1
 github.com/dell/goscaleio v1.2.0 h1:97x2rM0cRlBhy3povQe1OhxF4uI9vCgjRb/o19nP2d0=
 github.com/dell/goscaleio v1.2.0/go.mod h1:xrLhA17HgAXG616N7jQOatzVuxeZ5rfYsGSUBaQ7U8I=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
# Description

As part of CVE-2020-26160 there was a fix in #103 to remove dependencies to jwt-go. There was a lingering entry in go.mod however the library was not in use in the code. This PR removes those lingering references.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|          |

# Checklist:

- [x] I have performed a self-review of my own changes.