### PR TITLE
Dynamic configuration

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -51,8 +51,12 @@ import (
 	"google.golang.org/grpc"
 )
 
-// build is to be set via build flags in the makefile.
-var build = "develop"
+var (
+	// build is to be set via build flags in the makefile.
+	build            = "develop"
+	cfg              Config
+	JWTSigningSecret = "secret"
+)
 
 func init() {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -67,40 +71,40 @@ func main() {
 	}
 }
 
-func run(log *logrus.Entry) error {
-	var cfg struct {
-		Version string
-		Zipkin  struct {
-			CollectorURI string
-			ServiceName  string
-			Probability  float64
-		}
-		Certificate struct {
-			CrtFile         string
-			KeyFile         string
-			RootCertificate string
-		}
-		Proxy struct {
-			Host         string
-			ReadTimeout  time.Duration
-			WriteTimeout time.Duration
-		}
-		Web struct {
-			ShowDebugHTTP    bool
-			DebugHost        string
-			ShutdownTimeout  time.Duration
-			SidecarProxyAddr string
-			JWTSigningSecret string
-		}
-		Database struct {
-			Host     string
-			Password string
-		}
-		OpenPolicyAgent struct {
-			Host string
-		}
+type Config struct {
+	Version string
+	Zipkin  struct {
+		CollectorURI string
+		ServiceName  string
+		Probability  float64
 	}
+	Certificate struct {
+		CrtFile         string
+		KeyFile         string
+		RootCertificate string
+	}
+	Proxy struct {
+		Host         string
+		ReadTimeout  time.Duration
+		WriteTimeout time.Duration
+	}
+	Web struct {
+		ShowDebugHTTP    bool
+		DebugHost        string
+		ShutdownTimeout  time.Duration
+		SidecarProxyAddr string
+		JWTSigningSecret string
+	}
+	Database struct {
+		Host     string
+		Password string
+	}
+	OpenPolicyAgent struct {
+		Host string
+	}
+}
 
+func run(log *logrus.Entry) error {
 	cfgViper := viper.New()
 	cfgViper.SetConfigName("config")
 	cfgViper.AddConfigPath(".")
@@ -134,6 +138,13 @@ func run(log *logrus.Entry) error {
 	if err := cfgViper.Unmarshal(&cfg); err != nil {
 		log.Fatalf("decoding config file: %+v", err)
 	}
+
+	web.SidecarProxyAddr = cfg.Web.SidecarProxyAddr
+
+	cfgViper.WatchConfig()
+	cfgViper.OnConfigChange(func(e fsnotify.Event) {
+		updateConfiguration(cfgViper, log)
+	})
 
 	log.Infof("Config: %+v", cfg)
 
@@ -284,19 +295,19 @@ func run(log *logrus.Entry) error {
 	// Create the handlers
 
 	systemHandlers := map[string]http.Handler{
-		"powerflex":  web.Adapt(powerFlexHandler, web.OtelMW(tp, "powerflex"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256), cfg.Web.JWTSigningSecret)),
-		"powermax":   web.Adapt(powerMaxHandler, web.OtelMW(tp, "powermax"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256), cfg.Web.JWTSigningSecret)),
-		"powerscale": web.Adapt(powerScaleHandler, web.OtelMW(tp, "powerscale"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256), cfg.Web.JWTSigningSecret)),
+		"powerflex":  web.Adapt(powerFlexHandler, web.OtelMW(tp, "powerflex"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256))),
+		"powermax":   web.Adapt(powerMaxHandler, web.OtelMW(tp, "powermax"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256))),
+		"powerscale": web.Adapt(powerScaleHandler, web.OtelMW(tp, "powerscale"), web.AuthMW(log, jwx.NewTokenManager(jwx.HS256))),
 	}
 	dh := proxy.NewDispatchHandler(log, systemHandlers)
 
-	insecure := cfg.Certificate.CrtFile == "" && cfg.Certificate.KeyFile == ""
+	web.Insecure = cfg.Certificate.CrtFile == "" && cfg.Certificate.KeyFile == ""
 
 	router := &web.Router{
 		RolesHandler: web.Adapt(rolesHandler(log), web.OtelMW(tp, "roles")),
-		TokenHandler: web.Adapt(refreshTokenHandler(cfg.Web.JWTSigningSecret, log), web.OtelMW(tp, "refresh")),
+		TokenHandler: web.Adapt(refreshTokenHandler(log), web.OtelMW(tp, "refresh")),
 		ProxyHandler: web.Adapt(dh, web.OtelMW(tp, "dispatch")),
-		ClientInstallScriptHandler: web.Adapt(web.ClientInstallHandler(cfg.Web.SidecarProxyAddr, cfg.Web.JWTSigningSecret, cfg.Certificate.RootCertificate, insecure),
+		ClientInstallScriptHandler: web.Adapt(web.ClientInstallHandler(),
 			web.OtelMW(tp, "client-installer")),
 	}
 
@@ -350,6 +361,54 @@ func run(log *logrus.Entry) error {
 	return nil
 }
 
+func updateConfiguration(vc *viper.Viper, log *logrus.Entry) {
+	crtFile := cfg.Certificate.CrtFile
+	if vc.IsSet("certificate.crtfile") {
+		value := vc.GetString("certificate.crtfile")
+		crtFile = value
+		if crtFile != "" {
+			log.WithField("certificate.crtfile", crtFile).Info("configuration has been set.")
+		}
+	}
+
+	keyFile := cfg.Certificate.KeyFile
+	if vc.IsSet("certificate.keyfile") {
+		value := vc.GetString("certificate.keyfile")
+		keyFile = value
+		if keyFile != "" {
+			log.WithField("certificate.keyfile", keyFile).Info("configuration has been set.")
+		}
+	}
+	web.Insecure = crtFile == "" && keyFile == ""
+
+	rootCertFile := cfg.Certificate.RootCertificate
+	if vc.IsSet("certificate.rootcertificate") {
+		value := vc.GetString("certificate.rootcertificate")
+		rootCertFile = value
+		if rootCertFile != "" {
+			log.WithField("web.rootcertificate", rootCertFile).Info("configuration has been set.")
+		}
+	}
+	web.RootCertificate = rootCertFile
+
+	sidecarProxyAddr := cfg.Web.SidecarProxyAddr
+	if vc.IsSet("web.sidecarproxyaddr") {
+		value := vc.GetString("web.sidecarproxyaddr")
+		sidecarProxyAddr = value
+		log.WithField("web.sidecarproxyaddr", sidecarProxyAddr).Info("configuration has been set.")
+	}
+	web.SidecarProxyAddr = sidecarProxyAddr
+
+	jwtSigningSecret := cfg.Web.JWTSigningSecret
+	if vc.IsSet("web.jwtsigningsecret") {
+		value := vc.GetString("web.jwtsigningsecret")
+		jwtSigningSecret = value
+		log.WithField("web.jwtsigningsecret", jwtSigningSecret).Info("configuration has been set.")
+	}
+	web.JWTSigningSecret = jwtSigningSecret
+	JWTSigningSecret = jwtSigningSecret
+}
+
 func initTracing(log *logrus.Entry, uri, name string, prob float64) (*trace.TracerProvider, error) {
 	if len(strings.TrimSpace(uri)) == 0 {
 		return nil, nil
@@ -380,7 +439,7 @@ func initTracing(log *logrus.Entry, uri, name string, prob float64) (*trace.Trac
 	return tp, nil
 }
 
-func refreshTokenHandler(secret string, log *logrus.Entry) http.Handler {
+func refreshTokenHandler(log *logrus.Entry) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(ian): Establish this connection as part of service initialization.
 		conn, err := grpc.Dial("tenant-service.karavi.svc.cluster.local:50051",
@@ -410,7 +469,7 @@ func refreshTokenHandler(secret string, log *logrus.Entry) http.Handler {
 		refreshResp, err := client.RefreshToken(r.Context(), &pb.RefreshTokenRequest{
 			AccessToken:      input.AccessToken,
 			RefreshToken:     input.RefreshToken,
-			JWTSigningSecret: secret,
+			JWTSigningSecret: JWTSigningSecret,
 		})
 		if err != nil {
 			log.WithError(err).Error("refreshing token")

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -56,7 +56,7 @@ const (
 	certificateKeyFile = "certificate.keyfile"
 	rootCertFile       = "certificate.rootcertificate"
 	sidecarProxyAddr   = "web.sidecarproxyaddr"
-	jwtSigningSecret   = "web.jwtsigningsecret"
+	jwtSigningScrt     = "web.jwtsigningsecret"
 	logLevel           = "LOG_LEVEL"
 	logFormat          = "LOG_FORMAT"
 )
@@ -132,7 +132,7 @@ func run(log *logrus.Entry) error {
 	cfgViper.SetDefault("web.debughost", ":9090")
 	cfgViper.SetDefault("web.shutdowntimeout", 15*time.Second)
 	cfgViper.SetDefault(sidecarProxyAddr, web.DefaultSidecarProxyAddr)
-	cfgViper.SetDefault(jwtSigningSecret, "secret")
+	cfgViper.SetDefault(jwtSigningScrt, "secret")
 	cfgViper.SetDefault("web.showdebughttp", false)
 
 	cfgViper.SetDefault("zipkin.collectoruri", "")
@@ -415,10 +415,10 @@ func updateConfiguration(vc *viper.Viper, log *logrus.Entry) {
 	web.SidecarProxyAddr = spa
 
 	jss := cfg.Web.JWTSigningSecret
-	if vc.IsSet(jwtSigningSecret) {
-		value := vc.GetString(jwtSigningSecret)
+	if vc.IsSet(jwtSigningScrt) {
+		value := vc.GetString(jwtSigningScrt)
 		jss = value
-		log.WithField(jwtSigningSecret, jwtSigningSecret).Info("configuration has been set.")
+		log.WithField(jwtSigningScrt, jwtSigningScrt).Info("configuration has been set.")
 	}
 	web.JWTSigningSecret = jss
 	JWTSigningSecret = jss

--- a/cmd/proxy-server/main_test.go
+++ b/cmd/proxy-server/main_test.go
@@ -14,8 +14,57 @@
 
 package main
 
-import "testing"
+import (
+	"karavi-authorization/internal/web"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
 
 func TestProxy(t *testing.T) {
 	t.Skip("TODO")
+}
+
+func TestUpdateConfiguration(t *testing.T) {
+	v := viper.New()
+	v.Set("certificate.crtfile", "testCrtFile")
+	v.Set("certificate.keyfile", "testKeyFile")
+	v.Set("certificate.rootcertificate", "testRootCertificate")
+	v.Set("web.sidecarproxyaddr", "127.0.0.1:5000/sidecar-proxy:test")
+	v.Set("web.jwtsigningsecret", "testSecret")
+
+	oldCfg := cfg
+	cfg = Config{}
+
+	oldInsecure := web.Insecure
+	oldRootCert := web.RootCertificate
+	oldSidecarProxyAddr := web.SidecarProxyAddr
+	oldJWTSigningSecret := JWTSigningSecret
+
+	defer func() {
+		cfg = oldCfg
+		web.Insecure = oldInsecure
+		web.RootCertificate = oldRootCert
+		web.SidecarProxyAddr = oldSidecarProxyAddr
+		JWTSigningSecret = oldJWTSigningSecret
+	}()
+
+	updateConfiguration(v, logrus.NewEntry(logrus.StandardLogger()))
+
+	if web.Insecure != false {
+		t.Errorf("expeted web.Insecure to be %v, got %v", false, web.Insecure)
+	}
+
+	if web.RootCertificate != "testRootCertificate" {
+		t.Errorf("expeted web.RootCertificate to be %v, got %v", "testRootCertificate", web.RootCertificate)
+	}
+
+	if web.SidecarProxyAddr != "127.0.0.1:5000/sidecar-proxy:test" {
+		t.Errorf("expeted web.sidecarproxyaddr to be %v, got %v", "127.0.0.1:5000/sidecar-proxy:test", web.SidecarProxyAddr)
+	}
+
+	if JWTSigningSecret != "testSecret" {
+		t.Errorf("expeted web.jwtsigningsecret to be %v, got %v", "testSecret", JWTSigningSecret)
+	}
 }

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -50,6 +50,8 @@ const (
 	HeaderForwarded = "Forwarded"
 	Bearer          = "Bearer "
 	ContentType     = "application/json"
+	csiLogLevel     = "CSI_LOG_LEVEL"
+	csiLogFormat    = "CSI_LOG_FORMAT"
 )
 
 // Hooks that may be overridden for testing.
@@ -223,14 +225,14 @@ func run(log *logrus.Entry) error {
 	}
 
 	updateLoggingSettings := func(log *logrus.Entry) {
-		logFormat := driverCfg.GetString("CSI_LOG_FORMAT")
+		logFormat := driverCfg.GetString(csiLogFormat)
 		if strings.EqualFold(logFormat, "json") {
 			log.Logger.SetFormatter(&logrus.JSONFormatter{})
 		} else {
 			// use text formatter by default
 			log.Logger.SetFormatter(&logrus.TextFormatter{})
 		}
-		logLevel := driverCfg.GetString("CSI_LOG_LEVEL")
+		logLevel := driverCfg.GetString(csiLogLevel)
 		level, err := logrus.ParseLevel(logLevel)
 		if err != nil {
 			// use INFO level by default

--- a/cmd/tenant-service/main.go
+++ b/cmd/tenant-service/main.go
@@ -31,10 +31,16 @@ import (
 	"google.golang.org/grpc"
 )
 
+const (
+	logLevel  = "LOG_LEVEL"
+	logFormat = "LOG_FORMAT"
+)
+
 var (
 	cfg Config
 )
 
+// Config is the configuration details on the tenant-service
 type Config struct {
 	GrpcListenAddr string
 	Version        string
@@ -98,14 +104,14 @@ func main() {
 	}
 
 	updateLoggingSettings := func(log *logrus.Entry) {
-		logFormat := csmViper.GetString("LOG_FORMAT")
+		logFormat := csmViper.GetString(logFormat)
 		if strings.EqualFold(logFormat, "json") {
 			log.Logger.SetFormatter(&logrus.JSONFormatter{})
 		} else {
 			// use text formatter by default
 			log.Logger.SetFormatter(&logrus.TextFormatter{})
 		}
-		logLevel := csmViper.GetString("LOG_LEVEL")
+		logLevel := csmViper.GetString(logLevel)
 		level, err := logrus.ParseLevel(logLevel)
 		if err != nil {
 			// use INFO level by default

--- a/cmd/tenant-service/main_test.go
+++ b/cmd/tenant-service/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"karavi-authorization/internal/tenantsvc"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func TestUpdateConfiguration(t *testing.T) {
+	v := viper.New()
+	v.Set("web.jwtsigningsecret", "testSecret")
+
+	oldCfg := cfg
+	cfg = Config{}
+
+	oldJWTSigningSecret := tenantsvc.JWTSigningSecret
+
+	defer func() {
+		cfg = oldCfg
+		tenantsvc.JWTSigningSecret = oldJWTSigningSecret
+	}()
+
+	updateConfiguration(v, logrus.NewEntry(logrus.StandardLogger()))
+
+	if tenantsvc.JWTSigningSecret != "testSecret" {
+		t.Errorf("expeted web.jwtsigningsecret to be %v, got %v", "testSecret", tenantsvc.JWTSigningSecret)
+	}
+}

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -118,7 +118,7 @@ Karavi Authorization has a subset of configuration parameters that can be update
 | web.sidecarproxyaddr | String |"127.0.0.1:5000/sidecar-proxy:latest" |Docker registry address of the Karavi Authorization sidecar-proxy |
 | web.jwtsigningsecret | String | "secret" |The secret used to sign JWT tokens | 
 
-This can be done by editing the karavi-config-secret. The secret can be queried using k3s and kubectl like so: `k3s kubectl -n karavi get secret/karavi-config-secret`. 
+Updating configuration parameters can be done by editing the karavi-config-secret. The secret can be queried using k3s and kubectl like so: `k3s kubectl -n karavi get secret/karavi-config-secret`. 
 
 To update or add parameters, you must edit the base64 encoded data in the secret. The karavi-config-secret data can be decoded like so:
 

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -120,7 +120,7 @@ Karavi Authorization has a subset of configuration parameters that can be update
 
 Updating configuration parameters can be done by editing the `karavi-config-secret`. The secret can be queried using k3s and kubectl like so: 
 
-`k3s kubectl -n karavi get secret/karavi-config-secret`. 
+`k3s kubectl -n karavi get secret/karavi-config-secret`
 
 To update or add parameters, you must edit the base64 encoded data in the secret. The` karavi-config-secret` data can be decoded like so:
 

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -118,9 +118,11 @@ Karavi Authorization has a subset of configuration parameters that can be update
 | web.sidecarproxyaddr | String |"127.0.0.1:5000/sidecar-proxy:latest" |Docker registry address of the Karavi Authorization sidecar-proxy |
 | web.jwtsigningsecret | String | "secret" |The secret used to sign JWT tokens | 
 
-Updating configuration parameters can be done by editing the karavi-config-secret. The secret can be queried using k3s and kubectl like so: `k3s kubectl -n karavi get secret/karavi-config-secret`. 
+Updating configuration parameters can be done by editing the `karavi-config-secret`. The secret can be queried using k3s and kubectl like so: 
 
-To update or add parameters, you must edit the base64 encoded data in the secret. The karavi-config-secret data can be decoded like so:
+`k3s kubectl -n karavi get secret/karavi-config-secret`. 
+
+To update or add parameters, you must edit the base64 encoded data in the secret. The` karavi-config-secret` data can be decoded like so:
 
 `k3s kubectl -n karavi get secret/karavi-config-secret -o yaml | grep config.yaml | head -n 1 | awk '{print $2}' | base64 -d`
 
@@ -128,19 +130,19 @@ Save the output to a file or copy it to an editor to make changes. Once you are 
 
 `cat <file> | base64`
 
-Copy the new, encoded data and edit the karavi-config-secret with the new data. Run this command to edit the secret:
+Copy the new, encoded data and edit the `karavi-config-secret` with the new data. Run this command to edit the secret:
 
 `k3s kubectl -n karavi edit secret/karavi-config-secret`
 
 Replace the data in `config.yaml` under the `data` field with your new, encoded data. Save the changes and Karavi Authorization will read the changed secret.
 
-*Note*: If you are updating the signing secret, the tenants need to be updated with new tokens via the `karavictl generate token` command like so:
+**Note**: If you are updating the signing secret, the tenants need to be updated with new tokens via the `karavictl generate token` command like so:
 
 `karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationHost}" | jq -r '.Token' > kubectl -n $namespace apply -f -`
 
 ## Other Dynamic Configuration Settings
 
-Some settings are not stored in the karavi-config-secret but in the csm-config-params ConfigMap, such as LOG_LEVEL and LOG_FORMAT. To update the karavi-authorization logging settings during runtime, run the below command on the K3s cluster, make your changes, and save the updated configmap data.
+Some settings are not stored in the `karavi-config-secret` but in the csm-config-params ConfigMap, such as LOG_LEVEL and LOG_FORMAT. To update the karavi-authorization logging settings during runtime, run the below command on the K3s cluster, make your changes, and save the updated configmap data.
 
 ```
 k3s kubectl -n karavi edit configmap/csm-config-params

--- a/internal/proxy/powermax_handler_test.go
+++ b/internal/proxy/powermax_handler_test.go
@@ -135,7 +135,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
-		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256), "secret")).ServeHTTP(w, r)
+		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256))).ServeHTTP(w, r)
 
 		if !gotCalled {
 			t.Errorf("wanted fake unisphere to be called, but it wasn't")
@@ -189,7 +189,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
-		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256), "secret")).ServeHTTP(w, r)
+		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256))).ServeHTTP(w, r)
 
 		if w.Result().StatusCode != http.StatusOK {
 			t.Errorf("status: got %d, want 200", w.Result().StatusCode)
@@ -256,7 +256,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
-		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256), "secret")).ServeHTTP(w, r)
+		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256))).ServeHTTP(w, r)
 
 		if w.Result().StatusCode != http.StatusOK {
 			t.Errorf("status: got %d, want 200", w.Result().StatusCode)

--- a/internal/proxy/powerscale_handler_test.go
+++ b/internal/proxy/powerscale_handler_test.go
@@ -120,7 +120,7 @@ func testPowerScaleServeHTTP(t *testing.T) {
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
-		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256), "secret")).ServeHTTP(w, r)
+		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256))).ServeHTTP(w, r)
 
 		if w.Result().StatusCode != http.StatusOK {
 			t.Errorf("status: got %d, want 200", w.Result().StatusCode)
@@ -179,7 +179,7 @@ func testPowerScaleServeHTTP(t *testing.T) {
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
-		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256), "secret")).ServeHTTP(w, r)
+		web.Adapt(sut, web.AuthMW(discardLogger(), jwx.NewTokenManager(jwx.HS256))).ServeHTTP(w, r)
 
 		if w.Result().StatusCode != http.StatusOK {
 			t.Errorf("status: got %d, want 200", w.Result().StatusCode)

--- a/internal/tenantsvc/service.go
+++ b/internal/tenantsvc/service.go
@@ -38,6 +38,7 @@ var (
 	ErrNoRolesForTenant    = status.Error(codes.InvalidArgument, "tenant has no roles")
 	ErrTenantIsRevoked     = status.Error(codes.InvalidArgument, "tenant has been revoked")
 
+	// JWTSigningSecret is the secret string used to sign JWT tokens
 	JWTSigningSecret = "secret"
 )
 

--- a/internal/tenantsvc/service.go
+++ b/internal/tenantsvc/service.go
@@ -54,8 +54,7 @@ type TenantService struct {
 
 	log *logrus.Entry
 	rdb *redis.Client
-	//jwtSigningSecret string
-	tm token.Manager
+	tm  token.Manager
 }
 
 // Option allows for functional option arguments on the TenantService.

--- a/internal/web/client_install_handler.go
+++ b/internal/web/client_install_handler.go
@@ -11,8 +11,16 @@ import (
 var DefaultSidecarProxyAddr = "127.0.0.1:5000/sidecar-proxy:latest"
 
 var (
-	RootCertificate  = ""
-	Insecure         = false
+	// RootCertificate is the path to the root CA of the proxy-server and is passed in to the "--root-certificate" flag
+	// Set by providing the file path in "certificate.rootcertificate"
+	RootCertificate = ""
+
+	// Insecure is passed in to the "--insecure" flag
+	// Set to true by providing the file paths in "certificate.crtfile" and "certificate.keyfile"
+	Insecure = false
+
+	// SidecarProxyAddr is the docker registry address of the sidecar-proxy image
+	// Set via "web.sidecarproxyaddr"
 	SidecarProxyAddr = DefaultSidecarProxyAddr
 )
 

--- a/internal/web/client_install_handler.go
+++ b/internal/web/client_install_handler.go
@@ -10,12 +10,18 @@ import (
 // download the sidecar proxy container image.
 var DefaultSidecarProxyAddr = "127.0.0.1:5000/sidecar-proxy:latest"
 
+var (
+	RootCertificate  = ""
+	Insecure         = false
+	SidecarProxyAddr = DefaultSidecarProxyAddr
+)
+
 // Guest is used for the Guest tenant and role name.
 const Guest = "Guest"
 
 // ClientInstallHandler returns a handler that will serve up an installer
 // script to requesting clients.
-func ClientInstallHandler(imageAddr, jwtSigningSecret, rootCA string, insecure bool) http.Handler {
+func ClientInstallHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
 		var sb strings.Builder
@@ -28,9 +34,9 @@ func ClientInstallHandler(imageAddr, jwtSigningSecret, rootCA string, insecure b
 			pps += fmt.Sprintf(" --proxy-port %s=%s", t[0], t[1])
 		}
 
-		inject := fmt.Sprintf("karavictl inject --image-addr %s --proxy-host %s --insecure=%v %s", imageAddr, host, insecure, pps)
-		if rootCA != "" {
-			inject += fmt.Sprintf(" --root-certificate %s", rootCA)
+		inject := fmt.Sprintf("karavictl inject --image-addr %s --proxy-host %s --insecure=%v %s", SidecarProxyAddr, host, Insecure, pps)
+		if RootCertificate != "" {
+			inject += fmt.Sprintf(" --root-certificate %s", RootCertificate)
 		}
 
 		checkDrivers := fmt.Sprintf(`

--- a/internal/web/client_install_handler_test.go
+++ b/internal/web/client_install_handler_test.go
@@ -29,7 +29,19 @@ func TestClientInstallHandler(t *testing.T) {
 	wantInsecureTkn := fmt.Sprintf("--insecure")
 	wantRootCATkn := fmt.Sprintf("--root-certificate")
 
-	web.ClientInstallHandler(imageAddr, "secret", "root-certificate.pem", false).ServeHTTP(w, r)
+	oldRootCert := web.RootCertificate
+	web.RootCertificate = "root-certificate.pem"
+	oldInsecure := web.Insecure
+	web.Insecure = false
+	oldSidecarProxyAddr := web.SidecarProxyAddr
+	web.SidecarProxyAddr = "127.0.0.1/sidecar:latest"
+	defer func() {
+		web.RootCertificate = oldRootCert
+		web.Insecure = oldInsecure
+		web.SidecarProxyAddr = oldSidecarProxyAddr
+	}()
+
+	web.ClientInstallHandler().ServeHTTP(w, r)
 	b, err := ioutil.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -41,6 +41,7 @@ const (
 )
 
 var (
+	// JWTSigningSecret is the secret string used to sign JWT tokens
 	JWTSigningSecret = "secret"
 )
 

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -40,6 +40,10 @@ const (
 	SystemIDKey                 // SystemIDKey is the context key for a system ID
 )
 
+var (
+	JWTSigningSecret = "secret"
+)
+
 // Middleware is a function that accepts an http Handler and returns an http Handler following the middleware pattern
 type Middleware func(http.Handler) http.Handler
 
@@ -102,7 +106,7 @@ func cleanPath(pth string) string {
 }
 
 // AuthMW configures validating the json web token from the request
-func AuthMW(log *logrus.Entry, tm token.Manager, secret string) Middleware {
+func AuthMW(log *logrus.Entry, tm token.Manager) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authz := r.Header.Get("Authorization")
@@ -116,7 +120,7 @@ func AuthMW(log *logrus.Entry, tm token.Manager, secret string) Middleware {
 			switch scheme {
 			case "Bearer":
 				var claims token.Claims
-				parsedToken, err := tm.ParseWithClaims(tkn, secret, &claims)
+				parsedToken, err := tm.ParseWithClaims(tkn, JWTSigningSecret, &claims)
 				if err != nil {
 					w.WriteHeader(http.StatusUnauthorized)
 					if err := JSONErrorResponse(w, err); err != nil {


### PR DESCRIPTION
# Description

This PR adds dynamic configuration of a subset of items in the karavi-config-secret:

- certificate.crtfile
- certificate.keyfile
- certificate.rootcertificate
- web.sidecarproxyaddr
- web.jwtsigningsecret

These items are removed from the middleware used to configure the proxy-server/handlers and now used as global variables which are updated by Viper.

The `certificate` and `web.sidecarproxyaddr` settings are used for injection. `web.jwtsigningsecret` can be changed to update the JWT secret on the fly. To edit the config secret, you'd execute these steps:

1. Run `k3s kubectl -n karavi edit secret/karavi-config-secret` to open the secret
2. Copy the base64 encoded data in `config.yaml` under the `data` field and decode it
3. Edit the decoded data to make changes and base64 encode it
4. Run the command in step 1 to open the secret
5. Replace the base64 encoded in `config.yaml` with your encoded changes

This was tested by executing these steps with the csi-vxflexos driver:

1. Inject the driver using the default config file in ~/.karavi/config.json
2. Edit the karavi-config-secret to use a different sidecar tag (functionally the same image) and a different JWT signing secret, wait for the config change in the proxy-server logs
3. Run `karavictl generate token ... | kubectl -n vxflexos apply -f -` to update the `proxy-authz-tokens` secret
4. Inject again to trigger request flows (injection not required, just used to test)

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #129       |

# Checklist:

- [x] I have performed a self-review of my own changes.

```
]# make test
docker run --rm -it -v /root/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
data.karavi.authz.url.test_get_api_login_allowed: PASS (1.246329ms)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (497.729µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (468.968µs)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (409.229µs)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (525.485µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (418.817µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (460.297µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (426.161µs)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (463.862µs)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (394.37µs)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (394.273µs)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (478.42µs)
data.karavi.volumes.create.test_small_request_allowed: PASS (1.223597ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (326.192µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  17.349s coverage: 65.4% of statements
ok      karavi-authorization/cmd/proxy-server   0.066s  coverage: 15.6% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
ok      karavi-authorization/cmd/tenant-service 0.048s  coverage: 9.4% of statements
ok      karavi-authorization/deploy     0.092s  coverage: 86.3% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.138s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     7.555s  coverage: 69.4% of statements
ok      karavi-authorization/internal/quota     0.369s  coverage: 90.1% of statements
ok      karavi-authorization/internal/roles     0.045s  coverage: 93.2% of statements
ok      karavi-authorization/internal/tenantsvc 1.507s  coverage: 82.3% of statements
ok      karavi-authorization/internal/token     0.037s  coverage: 90.9% of statements
ok      karavi-authorization/internal/token/jwx 0.036s  coverage: 71.7% of statements
ok      karavi-authorization/internal/web       0.036s  coverage: 28.4% of statements
?       karavi-authorization/pb [no test files]
```