### PR TITLE
Remove certificates from dynamic configuration and fix log messages

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -186,6 +186,7 @@ func run(log *logrus.Entry) error {
 			// use INFO level by default
 			level = logrus.InfoLevel
 		}
+		log.Infof("setting log level to %s", level.String())
 		log.Logger.SetLevel(level)
 		log.WithField(configParamLogLevel, level.String()).Info("configuration has been set")
 	}

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -52,7 +52,6 @@ import (
 )
 
 const (
-	rootCertFile                = "certificate.rootcertificate"
 	configParamSidecarProxyAddr = "web.sidecarproxyaddr"
 	configParamJWTSigningScrt   = "web.jwtsigningsecret"
 	configParamLogLevel         = "LOG_LEVEL"

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -52,8 +52,6 @@ import (
 )
 
 const (
-	certificateCrtFile          = "certificate.crtfile"
-	certificateKeyFile          = "certificate.keyfile"
 	rootCertFile                = "certificate.rootcertificate"
 	configParamSidecarProxyAddr = "web.sidecarproxyaddr"
 	configParamJWTSigningScrt   = "web.jwtsigningsecret"
@@ -122,8 +120,8 @@ func run(log *logrus.Entry) error {
 	cfgViper.AddConfigPath(".")
 	cfgViper.AddConfigPath("/etc/karavi-authorization/config/")
 
-	cfgViper.SetDefault(certificateCrtFile, "")
-	cfgViper.SetDefault(certificateKeyFile, "")
+	cfgViper.SetDefault("certificate.crtfile", "")
+	cfgViper.SetDefault("certificate.keyfile", "")
 
 	cfgViper.SetDefault("proxy.host", ":8080")
 	cfgViper.SetDefault("proxy.readtimeout", 30*time.Second)
@@ -178,7 +176,9 @@ func run(log *logrus.Entry) error {
 			// use text formatter by default
 			log.Logger.SetFormatter(&logrus.TextFormatter{})
 		}
-		log.WithField(configParamLogFormat, logFormat).Info("configuration has been set.")
+		if logFormat != "" {
+			log.WithField(configParamLogFormat, logFormat).Info("configuration has been set")
+		}
 
 		logLevel := csmViper.GetString(configParamLogLevel)
 		level, err := logrus.ParseLevel(logLevel)
@@ -187,7 +187,7 @@ func run(log *logrus.Entry) error {
 			level = logrus.InfoLevel
 		}
 		log.Logger.SetLevel(level)
-		log.WithField(configParamLogLevel, level).Info("configuration has been set.")
+		log.WithField(configParamLogLevel, level.String()).Info("configuration has been set")
 	}
 	updateLoggingSettings(log)
 

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -185,7 +185,9 @@ func run(log *logrus.Entry) error {
 			// use INFO level by default
 			level = logrus.InfoLevel
 		}
-		log.Infof("setting log level to %s", level.String())
+
+		// There are two log statements to ensure that we capture all LOG_LEVEL changes
+		log.WithField(configParamLogLevel, level.String()).Info("configuration has been set")
 		log.Logger.SetLevel(level)
 		log.WithField(configParamLogLevel, level.String()).Info("configuration has been set")
 	}

--- a/cmd/proxy-server/main_test.go
+++ b/cmd/proxy-server/main_test.go
@@ -37,28 +37,16 @@ func TestUpdateConfiguration(t *testing.T) {
 	oldCfg := cfg
 	cfg = Config{}
 
-	oldInsecure := web.Insecure
-	oldRootCert := web.RootCertificate
 	oldSidecarProxyAddr := web.SidecarProxyAddr
 	oldJWTSigningSecret := JWTSigningSecret
 
 	defer func() {
 		cfg = oldCfg
-		web.Insecure = oldInsecure
-		web.RootCertificate = oldRootCert
 		web.SidecarProxyAddr = oldSidecarProxyAddr
 		JWTSigningSecret = oldJWTSigningSecret
 	}()
 
 	updateConfiguration(v, logrus.NewEntry(logrus.StandardLogger()))
-
-	if web.Insecure != false {
-		t.Errorf("expeted web.Insecure to be %v, got %v", false, web.Insecure)
-	}
-
-	if web.RootCertificate != "testRootCertificate" {
-		t.Errorf("expeted web.RootCertificate to be %v, got %v", "testRootCertificate", web.RootCertificate)
-	}
 
 	if web.SidecarProxyAddr != "127.0.0.1:5000/sidecar-proxy:test" {
 		t.Errorf("expeted web.sidecarproxyaddr to be %v, got %v", "127.0.0.1:5000/sidecar-proxy:test", web.SidecarProxyAddr)

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -242,6 +242,7 @@ func run(log *logrus.Entry) error {
 			// use INFO level by default
 			level = logrus.InfoLevel
 		}
+		log.Infof("setting log level to %s", level.String())
 		log.Logger.SetLevel(level)
 		log.WithField(csiLogLevel, level.String()).Info("configuration has been set")
 	}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -242,7 +242,7 @@ func run(log *logrus.Entry) error {
 			// use INFO level by default
 			level = logrus.InfoLevel
 		}
-		log.Infof("setting log level to %s", level.String())
+		log.WithField(csiLogLevel, level.String()).Info("configuration has been set")
 		log.Logger.SetLevel(level)
 		log.WithField(csiLogLevel, level.String()).Info("configuration has been set")
 	}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -232,6 +232,10 @@ func run(log *logrus.Entry) error {
 			// use text formatter by default
 			log.Logger.SetFormatter(&logrus.TextFormatter{})
 		}
+		if logFormat != "" {
+			log.WithField(csiLogFormat, logFormat).Info("configuration has been set")
+		}
+
 		logLevel := driverCfg.GetString(csiLogLevel)
 		level, err := logrus.ParseLevel(logLevel)
 		if err != nil {
@@ -239,6 +243,7 @@ func run(log *logrus.Entry) error {
 			level = logrus.InfoLevel
 		}
 		log.Logger.SetLevel(level)
+		log.WithField(csiLogLevel, level.String()).Info("configuration has been set")
 	}
 	updateLoggingSettings(log)
 

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -139,7 +139,7 @@ Replace the data in `config.yaml` under the `data` field with your new, encoded 
 
 ## Other Dynamic Configuration Settings
 
-Some settings are not stored in the `karavi-config-secret` but in the csm-config-params ConfigMap, such as LOG_LEVEL and LOG_FORMAT. To update the karavi-authorization logging settings during runtime, run the below command on the K3s cluster, make your changes, and save the updated configmap data.
+Some settings are not stored in the `karavi-config-secret` but in the `csm-config-params` ConfigMap, such as LOG_LEVEL and LOG_FORMAT. To update the karavi-authorization logging settings during runtime, run the below command on the K3s cluster, make your changes, and save the updated configmap data.
 
 ```
 k3s kubectl -n karavi edit configmap/csm-config-params
@@ -152,6 +152,13 @@ kubectl -n <driver_namespace> edit configmap/<release_name>-config-params
 ```
 
 Using PowerFlex as an example, `kubectl -n vxflexos edit configmap/vxflexos-config-params` can be used to update the logging level of the sidecar-proxy and the driver.
+
+This is the list of parameters that can be updated via the `csm-config-params` ConfigMap:
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| LOG_LEVEL | String |"info" |Logging format output for the controller podmon sidecar. Should be "text" or "json" |
+| LOG_FORMAT | String | "text" |Logging level for the controller podmon sidecar. Standard values: 'info', 'error', 'warning', 'debug', 'trace' | 
 
 ## Roles and Responsibilities
 

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -112,10 +112,7 @@ Karavi Authorization has a subset of configuration parameters that can be update
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| certificate.crtFile | String | "" |Path to the host certificate file |
-| certificate.keyFile | String | "" |Path to the host private key file |
-| certificate.rootCertificate | String | "" |Path to the root CA file  |
-| web.sidecarproxyaddr | String |"127.0.0.1:5000/sidecar-proxy:latest" |Docker registry address of the Karavi Authorization sidecar-proxy |
+| web.sidecarproxyaddr | String |"127.0.0.1:5000/sidecar-proxy:latest" |Registry address of the Karavi Authorization sidecar-proxy |
 | web.jwtsigningsecret | String | "secret" |The secret used to sign JWT tokens | 
 
 Updating configuration parameters can be done by editing the `karavi-config-secret`. The secret can be queried using k3s and kubectl like so: 
@@ -136,7 +133,7 @@ Copy the new, encoded data and edit the `karavi-config-secret` with the new data
 
 Replace the data in `config.yaml` under the `data` field with your new, encoded data. Save the changes and Karavi Authorization will read the changed secret.
 
-**Note**: If you are updating the signing secret, the tenants need to be updated with new tokens via the `karavictl generate token` command like so:
+**Note**: If you are updating the signing secret, the tenants must be updated with new tokens via the `karavictl generate token` command like so:
 
 `karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationHost}" | jq -r '.Token' > kubectl -n $namespace apply -f -`
 
@@ -302,7 +299,7 @@ Storage Administrators can use `karavictl` to perform storage access role manage
 #### Creating Storage Access Roles
 
 ```
-karavictl roles create [file]
+karavictl role create [file]
 
 Flags:
   -h, --help               help for create
@@ -312,7 +309,7 @@ Flags:
 #### Updating Storage Access Roles
 
 ```
-karavictl roles update [flags]
+karavictl role update [flags]
 
 Flags:
   -h, --help               help for create
@@ -322,19 +319,19 @@ Flags:
 #### Listing Storage Access Roles
 
 ```
-karavictl roles list
+karavictl role list
 ```
 
 #### Getting Storage Access Role
 
 ```
-karavictl roles get <rolename>
+karavictl role get <rolename>
 ```
 
 #### Deleting Storage Access Role
 
 ```
-karavictl roles delete <rolename>
+karavictl role delete <rolename>
 ```
 
 ## Building Karavi Authorization

--- a/internal/web/client_install_handler.go
+++ b/internal/web/client_install_handler.go
@@ -11,14 +11,6 @@ import (
 var DefaultSidecarProxyAddr = "127.0.0.1:5000/sidecar-proxy:latest"
 
 var (
-	// RootCertificate is the path to the root CA of the proxy-server and is passed in to the "--root-certificate" flag
-	// Set by providing the file path in "certificate.rootcertificate"
-	RootCertificate = ""
-
-	// Insecure is passed in to the "--insecure" flag
-	// Set to true by providing the file paths in "certificate.crtfile" and "certificate.keyfile"
-	Insecure = false
-
 	// SidecarProxyAddr is the docker registry address of the sidecar-proxy image
 	// Set via "web.sidecarproxyaddr"
 	SidecarProxyAddr = DefaultSidecarProxyAddr
@@ -29,7 +21,7 @@ const Guest = "Guest"
 
 // ClientInstallHandler returns a handler that will serve up an installer
 // script to requesting clients.
-func ClientInstallHandler() http.Handler {
+func ClientInstallHandler(rootCA string, insecure bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
 		var sb strings.Builder
@@ -42,9 +34,9 @@ func ClientInstallHandler() http.Handler {
 			pps += fmt.Sprintf(" --proxy-port %s=%s", t[0], t[1])
 		}
 
-		inject := fmt.Sprintf("karavictl inject --image-addr %s --proxy-host %s --insecure=%v %s", SidecarProxyAddr, host, Insecure, pps)
-		if RootCertificate != "" {
-			inject += fmt.Sprintf(" --root-certificate %s", RootCertificate)
+		inject := fmt.Sprintf("karavictl inject --image-addr %s --proxy-host %s --insecure=%v %s", SidecarProxyAddr, host, insecure, pps)
+		if rootCA != "" {
+			inject += fmt.Sprintf(" --root-certificate %s", rootCA)
 		}
 
 		checkDrivers := fmt.Sprintf(`

--- a/internal/web/client_install_handler_test.go
+++ b/internal/web/client_install_handler_test.go
@@ -29,19 +29,13 @@ func TestClientInstallHandler(t *testing.T) {
 	wantInsecureTkn := fmt.Sprintf("--insecure")
 	wantRootCATkn := fmt.Sprintf("--root-certificate")
 
-	oldRootCert := web.RootCertificate
-	web.RootCertificate = "root-certificate.pem"
-	oldInsecure := web.Insecure
-	web.Insecure = false
 	oldSidecarProxyAddr := web.SidecarProxyAddr
 	web.SidecarProxyAddr = "127.0.0.1/sidecar:latest"
 	defer func() {
-		web.RootCertificate = oldRootCert
-		web.Insecure = oldInsecure
 		web.SidecarProxyAddr = oldSidecarProxyAddr
 	}()
 
-	web.ClientInstallHandler().ServeHTTP(w, r)
+	web.ClientInstallHandler("root-certificate.pem", false).ServeHTTP(w, r)
 	b, err := ioutil.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
# Description

This PR removes certificate related entities from the dynamic configuration. Observability and Resiliency do not support updating certificates so we can align with that. The configurable entities are now the signing secret and the sidecar-proxy registry address, along with the logging.

An issue is fixed where the logging does not indicate certain LOG_LEVEL changes. All LOG_LEVEL changes are now seen in the logs.

Documentation is updated around the `karavictl role` command.

Tested by manually updating log levels to various degrees and verifying the proxy-server logs.

```
# make test
docker run --rm -it -v /root/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
data.karavi.authz.url.test_get_api_login_allowed: PASS (1.284155ms)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (488.64µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (528.131µs)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (484.62µs)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (478.836µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (496.613µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (463.443µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (387.717µs)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (432.872µs)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (404.08µs)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (391.163µs)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (418.981µs)
data.karavi.volumes.create.test_small_request_allowed: PASS (1.155036ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (265.991µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  17.820s coverage: 65.3% of statements
ok      karavi-authorization/cmd/proxy-server   0.071s  coverage: 7.0% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
ok      karavi-authorization/cmd/tenant-service 0.062s  coverage: 9.4% of statements
ok      karavi-authorization/deploy     0.092s  coverage: 86.3% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.087s  coverage: 88.9% of statements
ok      karavi-authorization/internal/proxy     11.736s coverage: 69.4% of statements
ok      karavi-authorization/internal/quota     0.364s  coverage: 90.1% of statements
ok      karavi-authorization/internal/roles     0.038s  coverage: 93.2% of statements
ok      karavi-authorization/internal/tenantsvc 4.334s  coverage: 82.3% of statements
ok      karavi-authorization/internal/token     0.036s  coverage: 90.9% of statements
ok      karavi-authorization/internal/token/jwx 0.061s  coverage: 71.7% of statements
ok      karavi-authorization/internal/web       0.035s  coverage: 28.4% of statements
?       karavi-authorization/pb [no test files]
``` 

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|          |

# Checklist:

- [x] I have performed a self-review of my own changes.