### PR TITLE
All session responses have body and replace response body when reading

### DIFF
--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -133,6 +133,7 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 			return err
 		}
 		pi.log.Println("RESPONSE: " + string(b))
+        r.Body = ioutil.NopCloser(bytes.NewReader(b))
 		return nil
 	}
 

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -133,7 +133,7 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 			return err
 		}
 		pi.log.Println("RESPONSE: " + string(b))
-        r.Body = ioutil.NopCloser(bytes.NewReader(b))
+		r.Body = ioutil.NopCloser(bytes.NewReader(b))
 		return nil
 	}
 


### PR DESCRIPTION
# Description

When any valid GET or POST requests go to a PowerScale system at the `/session/1/session/` endpoint there is a response body showing info on the session. This response body is now included on POST responses too.

Also, when reading a response from the array that is proxied, we must make sure to replace the content of the response body so that the original body makes it to the driver. A small fix for a spot where this is an issue is also a part of this PR.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #106       |

# Checklist:

- [x] I have performed a self-review of my own changes.