### PR TITLE
Powerscale OPA policies fix

### DIFF
--- a/internal/proxy/powerscale_handler.go
+++ b/internal/proxy/powerscale_handler.go
@@ -494,7 +494,7 @@ func (s *PowerScaleSystem) volumeDeleteHandler(next http.Handler, enf *quota.Red
 		ans, err := decision.Can(func() decision.Query {
 			return decision.Query{
 				Host:   opaHost,
-				Policy: "/karavi/volumes/powerscale/delete",
+				Policy: "/karavi/volumes/delete",
 				Input: map[string]interface{}{
 					"claims": claims,
 				},

--- a/policies/powerscale_url.rego
+++ b/policies/powerscale_url.rego
@@ -36,7 +36,7 @@ allowlist = [
     "POST /proxy/refresh-token/"
 ]
 
-default allow = false
+default allow = true
 allow {
 	regex.match(allowlist[_], sprintf("%s %s", [input.method, input.url]))
 }


### PR DESCRIPTION
# Description
Two issues were discovered when testing auth with PowerScale both of which affected volume deletion on the backend storage array.
1. OPA was responding with an empty response on delete requests because the path used for the OPA handler was non-existent for volume deletes.
2. When the driver tries to delete a volume, there are many requests that need to go to the powerscale that are not just for deleting the volume. Many of these paths were not included in the PowerScale policy allow list.

This PR fixes the policy path for volume deletion and allows all API calls from the driver to pass through the Authorization proxy server.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Internal e2e test with PowerScale and manual verification of volumes being deleted on the PowerScale array.
