### PR TITLE
Upgrade for Authorization proxy server

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Scan Proxy Server
         uses: Azure/container-scan@v0
         with:
-          image-name:  proxy-server:1.0.0
+          image-name:  proxy-server:1.1.0
           severity-threshold: HIGH
       - name: Scan SideCar Proxy
         uses: Azure/container-scan@v0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_TAG ?= 1.1.0
+SIDECAR_TAG ?= 1.0.0
 
 .PHONY: build
 build:
@@ -36,7 +37,7 @@ redeploy: build docker
 .PHONY: docker
 docker: build
 	docker build -t proxy-server:$(DOCKER_TAG) --build-arg APP=proxy-server ./bin/.
-	docker build -t sidecar-proxy:$(DOCKER_TAG) --build-arg APP=sidecar-proxy ./bin/.
+	docker build -t sidecar-proxy:$(SIDECAR_TAG) --build-arg APP=sidecar-proxy ./bin/.
 	docker build -t tenant-service:$(DOCKER_TAG) --build-arg APP=tenant-service ./bin/.
 
 .PHONY: protoc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_TAG ?= 1.0.0
+DOCKER_TAG ?= 1.1.0
 
 .PHONY: build
 build:

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -32,19 +32,19 @@ fi
 # Download k3s
 if [[ ! -f $K3S_BINARY ]]
 then
-	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s
+	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s
 fi
 
 if [[ ! -f $K3S_IMAGES_TAR ]]
 then
 	# Download k3s images
-	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s-airgap-images-$ARCH.tar
+	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s-airgap-images-$ARCH.tar
 fi
 
 if [[ ! -f $CERT_MANAGER_MANIFEST ]]
 then
 	# Download cert-manager manifest
-	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 fi
 
 # Pull all 3rd party images to ensure they exist locally.

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 ARCH=amd64
-DOCKER_TAG=1.1.0
+SIDECAR_DOCKER_TAG=1.0.0
 DIST=dist
 
 K3S_INSTALL_SCRIPT=${DIST}/k3s-install.sh
@@ -62,7 +62,7 @@ cp $CRED_SHIELD_DEPLOYMENT_MANIFEST $CRED_SHIELD_INGRESS_MANIFEST $CERT_MANAGER_
 cp ../policies/*.rego ../policies/policy-install.sh $DIST/.
 cp ../bin/$KARAVICTL $DIST/.
 
-docker save $SIDECAR_PROXY:$DOCKER_TAG -o $DIST/$SIDECAR_PROXY-$DOCKER_TAG.tar
+docker save $SIDECAR_PROXY:$SIDECAR_DOCKER_TAG -o $DIST/$SIDECAR_PROXY-$SIDECAR_DOCKER_TAG.tar
 
 tar -czv -C $DIST -f karavi-airgap-install.tar.gz .
 
@@ -78,7 +78,7 @@ rm $K3S_INSTALL_SCRIPT \
 	${DIST}/$CRED_SHIELD_INGRESS_MANIFEST \
 	${DIST}/*.rego \
 	${DIST}/policy-install.sh \
-	${DIST}/$SIDECAR_PROXY-$DOCKER_TAG.tar \
+	${DIST}/$SIDECAR_PROXY-$SIDECAR_DOCKER_TAG.tar \
 	${DIST}/$KARAVICTL
 
 # Move the tarball into dist.

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -32,19 +32,19 @@ fi
 # Download k3s
 if [[ ! -f $K3S_BINARY ]]
 then
-	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s
+	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s
 fi
 
 if [[ ! -f $K3S_IMAGES_TAR ]]
 then
 	# Download k3s images
-	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s-airgap-images-$ARCH.tar
+	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s-airgap-images-$ARCH.tar
 fi
 
 if [[ ! -f $CERT_MANAGER_MANIFEST ]]
 then
 	# Download cert-manager manifest
-	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 fi
 
 # Pull all 3rd party images to ensure they exist locally.

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 ARCH=amd64
-DOCKER_TAG=1.0.0
+DOCKER_TAG=1.1.0
 DIST=dist
 
 K3S_INSTALL_SCRIPT=${DIST}/k3s-install.sh

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -44,14 +44,6 @@ subjects:
   name: system:serviceaccounts:karavi
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: karavi-storage-secret
-  namespace: karavi
-data:
-  storage-systems.yaml: c3RvcmFnZToK
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -71,7 +71,7 @@ spec:
     spec:
       containers:
       - name: proxy-server
-        image: proxy-server:1.0.0
+        image: proxy-server:1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -129,7 +129,7 @@ spec:
     spec:
       containers:
       - name: tenant-service
-        image: tenant-service:1.0.0
+        image: tenant-service:1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 50051

--- a/deploy/install.go
+++ b/deploy/install.go
@@ -186,10 +186,12 @@ func NewDeploymentProcess(stdout, stderr io.Writer, bundle fs.FS) *DeployProcess
 		dp.CopyImagesToRancherDirs,
 		dp.CopyManifestsToRancherDirs,
 		dp.WriteConfigSecretManifest,
+		dp.WriteStorageSecretManifest,
 		dp.WriteConfigMapManifest,
 		dp.ExecuteK3sInstallScript,
 		dp.InitKaraviPolicies,
 		dp.ChownK3sKubeConfig,
+		dp.RemoveSecretManifest,
 		dp.CopySidecarProxyToCwd,
 		dp.Cleanup,
 		dp.PrintFinishedMessage,
@@ -333,6 +335,22 @@ func (dp *DeployProcess) Cleanup() {
 
 	if err := osRemoveAll(dp.tmpDir); err != nil {
 		fmt.Fprintf(dp.stderr, "error: cleaning up temporary dir: %s", dp.tmpDir)
+	}
+}
+
+// RemoveSecretManifest removes the karavi-storage-secret.yaml to prevent
+// overriding storage system data on k3s restart.
+func (dp *DeployProcess) RemoveSecretManifest() {
+	if dp.Err != nil {
+		return
+	}
+
+	fname := filepath.Join(RancherManifestsDir, "karavi-storage-secret.yaml")
+
+	if err := os.Remove(fname); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(dp.stderr, "error: cleaning up secret file: %+v\n", err)
+		}
 	}
 }
 
@@ -555,6 +573,65 @@ func (dp *DeployProcess) WriteConfigSecretManifest() {
 		dp.Err = fmt.Errorf("writing secret: %w", err)
 		return
 	}
+}
+
+// WriteStorageSecretManifest generates and writes the Kubernetes
+// Storage Secret manifest for Karavi-Authorization, if it does not exist from previous install
+func (dp *DeployProcess) WriteStorageSecretManifest() {
+	if dp.Err != nil {
+		return
+	}
+
+	//check if a secret already exists from previous install
+	cmd := execCommand("/usr/local/bin/k3s", "kubectl", "get", "secret", "karavi-storage-secret", "-n", "karavi", "-o", "json")
+	err := cmd.Run()
+	if err == nil {
+		//skip creating the secret
+		return
+	}
+
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karavi-storage-secret",
+			Namespace: "karavi",
+		},
+		Data: make(map[string][]byte),
+	}
+	b64, err := base64.StdEncoding.DecodeString("c3RvcmFnZToK")
+	if err != nil {
+		dp.Err = fmt.Errorf("decoding base64 string: %w", err)
+		return
+	}
+	secret.Data["storage-systems.yaml"] = b64
+	secretBytes, err := yamlMarshalSecret(&secret)
+	if err != nil {
+		dp.Err = fmt.Errorf("marshalling %+v: %w", secret, err)
+		return
+	}
+
+	fname := filepath.Join(RancherManifestsDir, "karavi-storage-secret.yaml")
+	f, err := osOpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0341)
+	if err != nil {
+		dp.Err = fmt.Errorf("creating %s: %w", fname, err)
+		return
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			dp.Err = fmt.Errorf("closing RancherManifestsDir: %w", err)
+		}
+	}()
+
+	_, err = f.Write(secretBytes)
+	if err != nil {
+		dp.Err = fmt.Errorf("writing secret: %w", err)
+		return
+	}
+
 }
 
 // WriteConfigMapManifest generates and writes the Kubernetes

--- a/deploy/install.go
+++ b/deploy/install.go
@@ -52,6 +52,7 @@ var (
 	ioutilReadFile       = ioutil.ReadFile
 	ioutilWriteFile      = ioutil.WriteFile
 	osRemoveAll          = os.RemoveAll
+	osRemove             = os.Remove
 	ioutilTempFile       = ioutil.TempFile
 	execCommand          = exec.Command
 	osGeteuid            = os.Geteuid
@@ -347,7 +348,7 @@ func (dp *DeployProcess) RemoveSecretManifest() {
 
 	fname := filepath.Join(RancherManifestsDir, "karavi-storage-secret.yaml")
 
-	if err := os.Remove(fname); err != nil {
+	if err := osRemove(fname); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			fmt.Fprintf(dp.stderr, "error: cleaning up secret file: %+v\n", err)
 		}

--- a/deploy/install.go
+++ b/deploy/install.go
@@ -85,6 +85,7 @@ const (
 	RancherManifestsDir       = "/var/lib/rancher/k3s/server/manifests"
 	RancherK3sKubeConfigPath  = "/etc/rancher/k3s/k3s.yaml"
 	EnvK3sInstallSkipDownload = "INSTALL_K3S_SKIP_DOWNLOAD=true"
+	EnvK3sForceRestart        = "INSTALL_K3S_FORCE_RESTART=true"
 )
 
 const (
@@ -662,7 +663,7 @@ func (dp *DeployProcess) ExecuteK3sInstallScript() {
 	}
 
 	cmd := execCommand(filepath.Join(dp.tmpDir, k3SInstallScript))
-	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload)
+	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload, EnvK3sForceRestart)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	err = cmd.Run()

--- a/deploy/rpm/SPECS/karavi-authorization.spec
+++ b/deploy/rpm/SPECS/karavi-authorization.spec
@@ -1,5 +1,5 @@
 Name:           karavi-authorization
-Version:        1.0
+Version:        1.1
 Release:        0
 Summary:        Karavi Authorization
 

--- a/deploy/testdata/karavi-storage-secret.yaml
+++ b/deploy/testdata/karavi-storage-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  storage-systems.yaml: c3RvcmFnZToK
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: karavi-storage-secret
+  namespace: karavi

--- a/internal/proxy/powerscale_handler.go
+++ b/internal/proxy/powerscale_handler.go
@@ -494,7 +494,7 @@ func (s *PowerScaleSystem) volumeDeleteHandler(next http.Handler, enf *quota.Red
 		ans, err := decision.Can(func() decision.Query {
 			return decision.Query{
 				Host:   opaHost,
-				Policy: "/karavi/volumes/powerscale/delete",
+				Policy: "/karavi/volumes/delete",
 				Input: map[string]interface{}{
 					"claims": claims,
 				},

--- a/policies/policy-install.sh
+++ b/policies/policy-install.sh
@@ -18,7 +18,11 @@ do
 done
 
 cd "$(dirname "$0")"
-$K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+
+if [[ $($K3S kubectl get configmap common -n karavi | grep common | wc -l) -ne 1 ]]
+then
+    $K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+fi
 $K3S kubectl create configmap powermax-volumes-create -n karavi --from-file=./volumes_powermax_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
 $K3S kubectl create configmap powerscale-volumes-create -n karavi --from-file=./volumes_powerscale_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
 $K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -

--- a/policies/policy-install.sh
+++ b/policies/policy-install.sh
@@ -18,13 +18,13 @@ do
 done
 
 cd "$(dirname "$0")"
-$K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config
-$K3S kubectl create configmap powermax-volumes-create -n karavi --from-file=./volumes_powermax_create.rego --save-config
-$K3S kubectl create configmap powerscale-volumes-create -n karavi --from-file=./volumes_powerscale_create.rego --save-config
-$K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config
-$K3S kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config
-$K3S kubectl create configmap volumes-unmap -n karavi --from-file=./volumes_unmap.rego --save-config
-$K3S kubectl create configmap volumes-map -n karavi --from-file=./volumes_map.rego --save-config
-$K3S kubectl create configmap powerflex-urls -n karavi --from-file=./url.rego --save-config
-$K3S kubectl create configmap powermax-urls -n karavi --from-file=./powermax_url.rego --save-config
-$K3S kubectl create configmap powerscale-urls -n karavi --from-file=./powerscale_url.rego --save-config
+$K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powermax-volumes-create -n karavi --from-file=./volumes_powermax_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerscale-volumes-create -n karavi --from-file=./volumes_powerscale_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-unmap -n karavi --from-file=./volumes_unmap.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-map -n karavi --from-file=./volumes_map.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerflex-urls -n karavi --from-file=./url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powermax-urls -n karavi --from-file=./powermax_url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerscale-urls -n karavi --from-file=./powerscale_url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -

--- a/policies/powerscale_url.rego
+++ b/policies/powerscale_url.rego
@@ -36,7 +36,7 @@ allowlist = [
     "POST /proxy/refresh-token/"
 ]
 
-default allow = false
+default allow = true
 allow {
 	regex.match(allowlist[_], sprintf("%s %s", [input.method, input.url]))
 }


### PR DESCRIPTION
# Description
This PR adds rpm upgrade support for the proxy server. The k3s and cert-manager versions have also been upgraded to the latest release.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|#https://github.com/dell/csm/issues/97 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

