### PR TITLE
revert k3s version because of ingress issues

### DIFF
--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -32,19 +32,19 @@ fi
 # Download k3s
 if [[ ! -f $K3S_BINARY ]]
 then
-	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s
+	curl -kL -o $K3S_BINARY  https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s
 fi
 
 if [[ ! -f $K3S_IMAGES_TAR ]]
 then
 	# Download k3s images
-	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.22.2%2Bk3s2/k3s-airgap-images-$ARCH.tar
+	curl -kL -o $K3S_IMAGES_TAR https://github.com/rancher/k3s/releases/download/v1.18.10%2Bk3s1/k3s-airgap-images-$ARCH.tar
 fi
 
 if [[ ! -f $CERT_MANAGER_MANIFEST ]]
 then
 	# Download cert-manager manifest
-	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 fi
 
 # Pull all 3rd party images to ensure they exist locally.

--- a/deploy/ingress-traefik.yaml
+++ b/deploy/ingress-traefik.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: proxy-server
@@ -22,10 +22,10 @@ spec:
         - path: /
           pathType: Prefix
           backend:
-            service.name: proxy-server
-            service.port.number: 8080
+            serviceName: proxy-server
+            servicePort: 8080
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: grpc-services
@@ -49,5 +49,5 @@ spec:
       - path: /
         pathType: Prefix
         backend:
-          service.name: tenant-service
-          service.port.name: grpc
+          serviceName: tenant-service
+          servicePort: grpc


### PR DESCRIPTION
# Description
We discovered an incompatibility issue when upgrading to k3s 1.22.2 with ingress access to the tenant service. After reviewing and updating ingress-traefik.yaml to match the correct syntax (alleviating a 404 error) we encountered a 500 error when trying to create or list a tenant. The decision was made to forego upgrade to 1.22.2 for now as it removed the working ingress API (v1beta1). Needs further investigation why changes made were not sufficient to enable ingress on 1.22.2, perhaps using stable release 1.22.3

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [rpm update](https://github.com/dell/csm/issues/97)|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
