### PR TITLE
Security cleanup from sidecar logs

### DIFF
--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -157,7 +157,6 @@ func (pi *ProxyInstance) Handler(proxyHost url.URL, access, refresh string) http
 		pi.log.WithFields(logrus.Fields{
 			"proxy_host": proxyHost.Host,
 			"path":       r.URL.Path,
-			"headers":    r.Header,
 		}).Debug()
 
 		sw := &web.StatusWriter{
@@ -171,8 +170,6 @@ func (pi *ProxyInstance) Handler(proxyHost url.URL, access, refresh string) http
 			if err != nil {
 				pi.log.WithError(err).Error("refreshing tokens")
 			}
-			pi.log.Debugln(refresh)
-			pi.log.Debugln(access)
 		}
 	})
 }
@@ -263,7 +260,6 @@ func run(log *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("main: config: %+v\n", configs)
 
 	// Generate a self-signed certificate for the CSI driver to trust,
 	// since we will always be inside the same Pod talking over localhost.
@@ -278,6 +274,18 @@ func run(log *logrus.Entry) error {
 
 	var proxyInstances []*ProxyInstance
 	for _, v := range configs {
+		fields := map[string]interface{}{
+			"endpoint":         v.Endpoint,
+			"username":         v.Username,
+			"password":         "********",
+			"intendedendpoint": v.IntendedEndpoint,
+			"isDefault":        v.IsDefault,
+			"systemID":         v.SystemID,
+			"insecure":         v.Insecure,
+		}
+
+		log.WithFields(fields).Infof("main: config: ")
+
 		pi := &ProxyInstance{
 			log:              log,
 			PluginID:         pluginID,


### PR DESCRIPTION
# Description
Sidecar proxy logs have been cleaned up for security reasons.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

