### PR TITLE
Verbose token expired error

### DIFF
--- a/deploy/embed.go
+++ b/deploy/embed.go
@@ -1,3 +1,4 @@
+//go:build !prod
 // +build !prod
 
 package main

--- a/deploy/embed_prod.go
+++ b/deploy/embed_prod.go
@@ -1,3 +1,4 @@
+//go:build prod
 // +build prod
 
 package main

--- a/internal/proxy/powermax_handler_test.go
+++ b/internal/proxy/powermax_handler_test.go
@@ -43,13 +43,13 @@ func Test_handleError(t *testing.T) {
 		want bool
 	}{
 		{"nil error returns false", func() bool {
-			return handleError(nil, nil, 0, nil, "")
+			return handleError(nil, nil, http.StatusInternalServerError, nil, "")
 		}, false},
 		{"non-nil error, nil logger", func() bool {
-			return handleError(nil, httptest.NewRecorder(), 0, errors.New("test"), "")
+			return handleError(nil, httptest.NewRecorder(), http.StatusInternalServerError, errors.New("test"), "")
 		}, true},
 		{"non-nil logger", func() bool {
-			return handleError(logrus.NewEntry(logrus.New()), httptest.NewRecorder(), 0, errors.New("test"), "")
+			return handleError(logrus.NewEntry(logrus.New()), httptest.NewRecorder(), http.StatusInternalServerError, errors.New("test"), "")
 		}, true},
 	}
 	for _, tt := range tests {

--- a/internal/tenantsvc/service.go
+++ b/internal/tenantsvc/service.go
@@ -272,8 +272,8 @@ func (t *TenantService) RefreshToken(ctx context.Context, req *pb.RefreshTokenRe
 		return nil, errors.New("access token was valid")
 	}
 
-	switch err.(type) {
-	case *token.ErrExpired:
+	switch err {
+	case token.ErrExpired:
 		t.log.WithField("audience", accessClaims.Audience).Debug("Refreshing token")
 	default:
 		return nil, fmt.Errorf("jwt validation: %w", err)

--- a/internal/tenantsvc/service_test.go
+++ b/internal/tenantsvc/service_test.go
@@ -512,7 +512,7 @@ func createRedisContainer(t *testing.T) *redis.Client {
 		})
 	} else {
 		redisContainer, err := gnomock.StartCustom(
-			"10.247.66.155:5000/redis",
+			"docker.io/library/redis:latest",
 			gnomock.NamedPorts{"db": gnomock.TCP(6379)},
 			gnomock.WithDisableAutoCleanup())
 		if err != nil {

--- a/internal/tenantsvc/service_test.go
+++ b/internal/tenantsvc/service_test.go
@@ -512,7 +512,7 @@ func createRedisContainer(t *testing.T) *redis.Client {
 		})
 	} else {
 		redisContainer, err := gnomock.StartCustom(
-			"docker.io/library/redis:latest",
+			"10.247.66.155:5000/redis",
 			gnomock.NamedPorts{"db": gnomock.TCP(6379)},
 			gnomock.WithDisableAutoCleanup())
 		if err != nil {

--- a/internal/token/jwx/jwx.go
+++ b/internal/token/jwx/jwx.go
@@ -127,7 +127,7 @@ func (m *Manager) ParseWithClaims(tokenStr string, secret string, claims *token.
 	t, err := jwt.ParseString(tokenStr, jwt.WithValidate(true))
 	if err != nil {
 		if strings.Contains(err.Error(), errExpiredMsg) {
-			return nil, &token.ErrExpired{Err: err}
+			return nil, token.ErrExpired
 		}
 		return nil, err
 	}

--- a/internal/token/jwx/jwx_test.go
+++ b/internal/token/jwx/jwx_test.go
@@ -143,8 +143,8 @@ func TestParseWithClaims(t *testing.T) {
 			t.Errorf("expected non-nil err")
 		}
 
-		if v, ok := err.(*token.ErrExpired); !ok {
-			t.Errorf("got err type %T, want %T", v, token.ErrExpired{})
+		if err != token.ErrExpired {
+			t.Errorf("got %v, want %v", err, token.ErrExpired)
 		}
 	})
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -15,7 +15,12 @@
 package token
 
 import (
+	"errors"
 	"time"
+)
+
+var (
+	ErrExpired = errors.New("token has expired")
 )
 
 // Claims represents the standard JWT claims in addition
@@ -60,14 +65,4 @@ type Token interface {
 	Claims() (Claims, error)
 	// SignedString returns a token string signed with the secret
 	SignedString(secret string) (string, error)
-}
-
-// ErrExpired is an error to signify that a token has expired
-type ErrExpired struct {
-	Err error
-}
-
-// Error implements the error interface
-func (e *ErrExpired) Error() string {
-	return e.Err.Error()
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -20,6 +20,7 @@ import (
 )
 
 var (
+	// ErrExpired is the error for an expired token
 	ErrExpired = errors.New("token has expired")
 )
 


### PR DESCRIPTION
# Description
This PR updates the token expired error to use a static, more verbose error message instead of the package implementation of the expiration error.

Current error message for expired token: `exp not satisfied`.

New error message for expired token: `token has expired`.

This also adds preferred build tags for go 1.17. From https://go.dev/doc/go1.17:

"The go command now understands //go:build lines and prefers them over // +build lines. The new syntax uses boolean expressions, just like Go, and should be less error-prone. As of this release, the new syntax is fully supported, and all Go files should be updated to have both forms with the same meaning. To aid in migration, [gofmt](https://go.dev/doc/go1.17#gofmt) now automatically synchronizes the two forms. For more details on the syntax and migration plan, see [https://golang.org/design/draft-gobuild](https://go.dev/design/draft-gobuild).:

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/193 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Existing unit tests are sufficient to test this.
