### PR TITLE
Cancel tenant revokation on tenant deletion

### DIFF
--- a/internal/tenantsvc/service_test.go
+++ b/internal/tenantsvc/service_test.go
@@ -178,6 +178,23 @@ func testDeleteTenant(sut *tenantsvc.TenantService, afterFn AfterFunc) func(*tes
 				t.Error("DeleteTenant: expected non-nil error")
 			}
 		})
+		t.Run("it removes the revoked key", func(t *testing.T) {
+			defer afterFn()
+			name := "testname"
+			createTenant(t, sut, tenantConfig{Name: name, Revoked: true})
+
+			_, err := sut.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{
+				Name: name,
+			})
+			checkError(t, err)
+
+			_, gotErr := sut.GetTenant(context.Background(), &pb.GetTenantRequest{
+				Name: name,
+			})
+			if gotErr == nil {
+				t.Error("DeleteTenant: expected non-nil error")
+			}
+		})
 		t.Run("it errors on a non-existent tenant", func(t *testing.T) {
 			defer afterFn()
 			_, gotErr := sut.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{


### PR DESCRIPTION
# Description
This fixes a bug where a tenant is still considered revoked after it is deleted. A deleted tenant should not exist in the system.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/208|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

This was tested with a new unit test and verified in the e2e job.

```
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  2.267s  coverage: 61.0% of statements
ok      karavi-authorization/cmd/proxy-server   0.076s  coverage: 4.2% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
ok      karavi-authorization/cmd/tenant-service 0.046s  coverage: 9.4% of statements
ok      karavi-authorization/deploy     0.133s  coverage: 87.5% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.581s  coverage: 92.6% of statements
ok      karavi-authorization/internal/proxy     6.421s  coverage: 68.3% of statements
ok      karavi-authorization/internal/quota     0.316s  coverage: 90.1% of statements
ok      karavi-authorization/internal/roles     0.040s  coverage: 93.2% of statements
ok      karavi-authorization/internal/tenantsvc 1.460s  coverage: 82.3% of statements
ok      karavi-authorization/internal/token     0.034s  coverage: 100.0% of statements
ok      karavi-authorization/internal/token/jwx 0.041s  coverage: 71.7% of statements
ok      karavi-authorization/internal/web       0.041s  coverage: 6.2% of statements
?       karavi-authorization/pb [no test files]
```
