### PR TITLE
feature-261: Authorization helm chart

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -119,6 +119,7 @@ type Config struct {
 
 func run(log *logrus.Entry) error {
 	redisHost := flag.String("redis-host", "", "address of redis host")
+	tenantService := flag.String("tenant-service", "tenant-service.karavi.svc.cluster.local:50051", "address of tenant service")
 	flag.Parse()
 
 	cfgViper := viper.New()
@@ -339,7 +340,12 @@ func run(log *logrus.Entry) error {
 	}
 	dh := proxy.NewDispatchHandler(log, systemHandlers)
 
-	conn, err := grpc.Dial("tenant-service.karavi.svc.cluster.local:50051",
+	addr := "tenant-service.karavi.svc.cluster.local:50051"
+	if *tenantService != "" {
+		addr = *tenantService
+	}
+
+	conn, err := grpc.Dial(addr,
 		grpc.WithTimeout(10*time.Second),
 		grpc.WithInsecure())
 	if err != nil {

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -119,7 +119,7 @@ type Config struct {
 
 func run(log *logrus.Entry) error {
 	redisHost := flag.String("redis-host", "", "address of redis host")
-	tenantService := flag.String("tenant-service", "tenant-service.karavi.svc.cluster.local:50051", "address of tenant service")
+	tenantService := flag.String("tenant-service", "", "address of tenant service")
 	flag.Parse()
 
 	cfgViper := viper.New()

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"expvar"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -57,10 +58,9 @@ import (
 )
 
 const (
-	configParamSidecarProxyAddr = "web.sidecarproxyaddr"
-	configParamJWTSigningScrt   = "web.jwtsigningsecret"
-	configParamLogLevel         = "LOG_LEVEL"
-	configParamLogFormat        = "LOG_FORMAT"
+	configParamJWTSigningScrt = "web.jwtsigningsecret"
+	configParamLogLevel       = "LOG_LEVEL"
+	configParamLogFormat      = "LOG_FORMAT"
 )
 
 var (
@@ -118,6 +118,9 @@ type Config struct {
 }
 
 func run(log *logrus.Entry) error {
+	redisHost := flag.String("redis-host", "", "address of redis host")
+	flag.Parse()
+
 	cfgViper := viper.New()
 	cfgViper.SetConfigName("config")
 	cfgViper.AddConfigPath(".")
@@ -214,8 +217,13 @@ func run(log *logrus.Entry) error {
 
 	// Initialize database connections
 
+	redisAddr := cfg.Database.Host
+	if *redisHost != "" {
+		redisAddr = *redisHost
+	}
+
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     cfg.Database.Host, // "redis.karavi.svc.cluster.local:6379",
+		Addr:     redisAddr, // "redis.karavi.svc.cluster.local:6379",
 		Password: cfg.Database.Password,
 		DB:       0,
 	})

--- a/cmd/tenant-service/main.go
+++ b/cmd/tenant-service/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"karavi-authorization/internal/tenantsvc"
 	"karavi-authorization/internal/token/jwx"
@@ -62,6 +63,9 @@ type Config struct {
 
 func main() {
 	log := logrus.NewEntry(logrus.New())
+
+	redisHost := flag.String("redis-host", "", "address of redis host")
+	flag.Parse()
 
 	cfgViper := viper.New()
 	cfgViper.SetConfigName("config")
@@ -129,8 +133,13 @@ func main() {
 
 	// Initialize the database connection
 
+	redisAddr := cfg.Database.Host
+	if *redisHost != "" {
+		redisAddr = *redisHost
+	}
+
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     cfg.Database.Host, // "redis.karavi.svc.cluster.local:6379",
+		Addr:     redisAddr, // "redis.karavi.svc.cluster.local:6379",
 		Password: cfg.Database.Password,
 		DB:       0,
 	})
@@ -167,7 +176,7 @@ func updateConfiguration(vc *viper.Viper, log *logrus.Entry) {
 	if vc.IsSet("web.jwtsigningsecret") {
 		value := vc.GetString("web.jwtsigningsecret")
 		jwtSigningSecret = value
-		log.WithField("web.jwtsigningsecret", jwtSigningSecret).Info("configuration has been set.")
+		log.WithField("web.jwtsigningsecret", "***").Info("configuration has been set.")
 	}
 	tenantsvc.JWTSigningSecret = jwtSigningSecret
 }


### PR DESCRIPTION
# Description
This PR adds minor changes to support helm deployment and does some cleanup.

- `proxy-server` and `tenant-service` have flags for the address of redis which override default values
- removes the `configParamSidecarProxyAddr = "web.sidecarproxyaddr"` constant
- doesn't print the new signing secret on configuration update in the `tenant-service`

**Notes**

Service addresses are hardcoded to use k8s DNS. We will need proper service discovery to support other platforms.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/261 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manual deployment in k8s.

```
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  2.186s  coverage: 61.0% of statements
ok      karavi-authorization/cmd/proxy-server   0.079s  coverage: 4.0% of statements
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
ok      karavi-authorization/cmd/tenant-service 0.053s  coverage: 8.7% of statements
ok      karavi-authorization/deploy     0.105s  coverage: 87.5% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/powerflex 9.701s  coverage: 92.6% of statements
ok      karavi-authorization/internal/proxy     9.655s  coverage: 66.1% of statements
ok      karavi-authorization/internal/quota     0.412s  coverage: 90.1% of statements
ok      karavi-authorization/internal/roles     0.044s  coverage: 93.2% of statements
ok      karavi-authorization/internal/tenantsvc 7.362s  coverage: 82.3% of statements
ok      karavi-authorization/internal/token     0.040s  coverage: 100.0% of statements
ok      karavi-authorization/internal/token/jwx 0.033s  coverage: 71.7% of statements
ok      karavi-authorization/internal/web       0.048s  coverage: 6.2% of statements
?       karavi-authorization/pb [no test files]
```
