### PR TITLE
Update permissions of binaries during RPM installation

### DIFF
--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 ARCH=amd64
-SIDECAR_DOCKER_TAG=1.2.0
+SIDECAR_DOCKER_TAG=1.3.0
 DIST=dist
 
 K3S_INSTALL_SCRIPT=${DIST}/k3s-install.sh
@@ -55,7 +55,7 @@ for image in $(grep "image: docker.io" deployment.yaml | awk -F' ' '{ print $2 }
   docker pull $image
 done
 # Save all referenced images into a tarball.
-grep "image: " deployment.yaml | awk -F' ' '{ print $2 }' | xargs docker save -o $CRED_SHIELD_IMAGES_TAR
+grep "image: docker.io" deployment.yaml | awk -F' ' '{ print $2 }' | xargs docker save -o $CRED_SHIELD_IMAGES_TAR
 
 #Pull all images required to install cert-manager
 for image in $(grep "image: " ${DIST}/$CERT_MANAGER_MANIFEST | awk -F' ' '{ print $2 }' | xargs echo); do
@@ -83,7 +83,7 @@ rm $K3S_INSTALL_SCRIPT \
 	${DIST}/$CERT_MANAGER_MANIFEST \
 	${DIST}/$CERT_MANAGER_CONFIG_MANIFEST \
 	${DIST}/$CERT_MANIFEST \
-        ${DIST}/$CRED_SHIELD_DEPLOYMENT_MANIFEST \
+	${DIST}/$CRED_SHIELD_DEPLOYMENT_MANIFEST \
 	${DIST}/$CRED_SHIELD_INGRESS_MANIFEST \
 	${DIST}/*.rego \
 	${DIST}/policy-install.sh \

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -55,7 +55,7 @@ for image in $(grep "image: docker.io" deployment.yaml | awk -F' ' '{ print $2 }
   docker pull $image
 done
 # Save all referenced images into a tarball.
-grep "image: docker.io" deployment.yaml | awk -F' ' '{ print $2 }' | xargs docker save -o $CRED_SHIELD_IMAGES_TAR
+grep "image: " deployment.yaml | awk -F' ' '{ print $2 }' | xargs docker save -o $CRED_SHIELD_IMAGES_TAR
 
 #Pull all images required to install cert-manager
 for image in $(grep "image: " ${DIST}/$CERT_MANAGER_MANIFEST | awk -F' ' '{ print $2 }' | xargs echo); do

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
       - name: proxy-server
-        image: proxy-server:1.2.0
+        image: proxy-server:1.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
       - name: tenant-service
-        image: tenant-service:1.2.0
+        image: tenant-service:1.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 50051

--- a/deploy/install.go
+++ b/deploy/install.go
@@ -61,7 +61,6 @@ var (
 	yamlMarshalConfigMap = realYamlMarshalConfigMap
 	configDir            = "$HOME/.karavi/"
 	sidecarImageTar      = "sidecar-proxy-"
-	sidecarDockerImage   = "sidecar-proxy:"
 )
 
 const (
@@ -400,7 +399,7 @@ loop:
 				return
 			}
 
-			f, err := os.OpenFile(filepath.Clean(target), os.O_CREATE|os.O_RDWR, os.FileMode(755))
+			f, err := os.OpenFile(filepath.Clean(target), os.O_CREATE|os.O_RDWR, os.FileMode(0755))
 			if err != nil {
 				dp.Err = fmt.Errorf("creating file %q: %w", target, err)
 				return
@@ -434,7 +433,7 @@ func (dp *DeployProcess) InstallKaravictl() {
 		dp.Err = fmt.Errorf("installing karavictl: %w", err)
 		return
 	}
-	if err := osChmod(tgtPath, 755); err != nil {
+	if err := osChmod(tgtPath, 0755); err != nil {
 		dp.Err = fmt.Errorf("chmod karavictl: %w", err)
 		return
 	}
@@ -474,7 +473,7 @@ func (dp *DeployProcess) InstallK3s() {
 		dp.Err = fmt.Errorf("moving k3s binary: %w", err)
 		return
 	}
-	if err := osChmod(tgtPath, 755); err != nil {
+	if err := osChmod(tgtPath, 0755); err != nil {
 		dp.Err = fmt.Errorf("chmod k3s: %w", err)
 		return
 	}
@@ -725,7 +724,7 @@ func (dp *DeployProcess) ExecuteK3sInstallScript() {
 	defer fmt.Fprintln(dp.stdout, "Done!")
 
 	tmpPath := filepath.Join(dp.tmpDir, k3SInstallScript)
-	if err := osChmod(tmpPath, 755); err != nil {
+	if err := osChmod(tmpPath, 0755); err != nil {
 		dp.Err = fmt.Errorf("chmod %s: %w", k3SInstallScript, err)
 		return
 	}


### PR DESCRIPTION
# Description
This PR fixes incorrect integer values for adjusting permissions during RPM install. The integer value is read in as octal. This also fixes reference errors to the sidecar proxy and credential shield images when building the installer. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/277 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the RPM and checked for the correct permissions on the k3s and karavictl binaries (tested on RHEL 7.9)
