### PR TITLE
Fix issue if core-dns contains an entry for localhost

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -91,6 +91,7 @@ spec:
         args:
         - "--policies=karavi"
         - "--enable-data"
+        - "--opa-url=http://127.0.0.1:8181/v1"
       volumes:
       - name: config-volume
         secret:


### PR DESCRIPTION
# Description
If there is a DNS entry or entry in /etc/hosts for "localhost" that doesn't resolve to 127.0.0.1, the OPA policies in Authorization are in an error state. Relying on "localhost" is not sufficient if coredns does not resolve it to 127.0.0.1.

The fixes:
- Set default value of OPA host to `127.0.0.1:8181` instead of relying on localhost
- Deployment of kube-mgmt was using the default value of `http://localhost:8181/v1` for the OPA host. In deployment.yaml, this now uses `http://127.0.0.1:8181/v1`
 
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  https://github.com/dell/csm/issues/321 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Set localhost entry in /etc/hosts file pointing to a non-127.0.0.1 IP. Installed RPM, configured proxy server, injected driver and verified cert-csi was able to provision volumes.
