### PR TITLE
bug-328: allow all csi-powerflex paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module karavi-authorization
 
-go 1.17
+go 1.18
 
 require (
 	github.com/alicebob/miniredis/v2 v2.17.0

--- a/internal/proxy/powerflex_handler.go
+++ b/internal/proxy/powerflex_handler.go
@@ -207,6 +207,8 @@ func (h *PowerFlexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	mux.HandleFunc("/api/login/", h.spoofLoginRequest)
 	mux.Handle("/api/types/Volume/instances/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet:
+			proxyHandler.ServeHTTP(w, r)
 		case strings.HasSuffix(r.URL.Path, "/action/queryIdByKey/"):
 			proxyHandler.ServeHTTP(w, r)
 		default:

--- a/policies/url.rego
+++ b/policies/url.rego
@@ -33,7 +33,7 @@ allowlist = [
 		"POST /api/instances/Volume::[a-f0-9]+/action/removeVolume/"
 ]
 
-default allow = false
+default allow = true
 allow {
 	regex.match(allowlist[_], sprintf("%s %s", [input.method, input.url]))
 }


### PR DESCRIPTION
# Description

- Allows all PowerFlex API request paths from csi-powerflex
- Forwards the GET request to `/api/types/Volume/instances/` to the backend array
- Updates go.mod to 1.18

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/328 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manually verified that volume create/delete works.

```
# make test
docker run --rm -it -v /root/karavi-authorization/policies:/policies/ openpolicyagent/opa test -v /policies/
/policies/url_test.rego:
data.karavi.authz.url.test_get_api_login_allowed: PASS (991.737µs)
data.karavi.authz.url.test_post_proxy_refresh_token_allowed: PASS (379.853µs)
data.karavi.authz.url.test_get_api_version_allowed: PASS (364.695µs)
data.karavi.authz.url.test_get_system_instances_allowed: PASS (349.939µs)
data.karavi.authz.url.test_get_storagpool_instances_allowed: PASS (347.739µs)
data.karavi.authz.url.test_post_volume_instances_allowed: PASS (434.442µs)
data.karavi.authz.url.test_get_volume_instance_allowed: PASS (391.49µs)
data.karavi.authz.url.test_post_volume_instances_queryIdByKey_allowed: PASS (362.276µs)
data.karavi.authz.url.test_get_system_sdc_allowed: PASS (3.092931ms)
data.karavi.authz.url.test_post_volume_add_sdc_allowed: PASS (977.459µs)
data.karavi.authz.url.test_post_volume_remove_sdc_allowed: PASS (847.776µs)
data.karavi.authz.url.test_post_volume_remove_allowed: PASS (758.442µs)

/policies/volumes_create_test.rego:
data.karavi.volumes.create.test_small_request_allowed: PASS (1.383524ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (336.809µs)
--------------------------------------------------------------------------------
PASS: 14/14
go test -count=1 -cover -race -timeout 30s -short ./...
?       karavi-authorization/cmd/karavictl      [no test files]
ok      karavi-authorization/cmd/karavictl/cmd  3.602s  coverage: 65.6% of statements
ok      karavi-authorization/cmd/proxy-server   0.105s  coverage: 4.0% of statements
?       karavi-authorization/cmd/role-service   [no test files]
?       karavi-authorization/cmd/sidecar-proxy  [no test files]
?       karavi-authorization/cmd/storage-service        [no test files]
ok      karavi-authorization/cmd/tenant-service 0.042s  coverage: 8.7% of statements
ok      karavi-authorization/deploy     0.175s  coverage: 87.5% of statements
?       karavi-authorization/internal/decision  [no test files]
ok      karavi-authorization/internal/k8s       0.119s  coverage: 51.0% of statements
ok      karavi-authorization/internal/powerflex 9.587s  coverage: 92.6% of statements
ok      karavi-authorization/internal/proxy     9.431s  coverage: 66.0% of statements
ok      karavi-authorization/internal/quota     0.485s  coverage: 90.1% of statements
ok      karavi-authorization/internal/role-service      0.085s  coverage: 79.2% of statements
ok      karavi-authorization/internal/role-service/roles        0.052s  coverage: 87.4% of statements
ok      karavi-authorization/internal/role-service/validate     0.218s  coverage: 79.4% of statements
ok      karavi-authorization/internal/storage-service   0.066s  coverage: 92.8% of statements
ok      karavi-authorization/internal/storage-service/validate  0.245s  coverage: 91.2% of statements
ok      karavi-authorization/internal/tenantsvc 7.453s  coverage: 82.3% of statements
ok      karavi-authorization/internal/token     0.051s  coverage: 100.0% of statements
ok      karavi-authorization/internal/token/jwx 0.045s  coverage: 71.7% of statements
?       karavi-authorization/internal/types     [no test files]
ok      karavi-authorization/internal/web       0.058s  coverage: 6.2% of statements
?       karavi-authorization/pb [no test files]
```
