### PR TITLE
Update sidecarproxy to use skip certificate validation

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -98,23 +98,33 @@ jobs:
         with:
           image-name: proxy-server:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Role Service
         uses: Azure/container-scan@v0
         with:
           image-name: role-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Tenant Service
         uses: Azure/container-scan@v0
         with:
           image-name: tenant-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan SideCar Proxy
         uses: Azure/container-scan@v0
         with:
           image-name: sidecar-proxy:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Storage Service
         uses: Azure/container-scan@v0
         with:
           image-name: storage-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -126,5 +126,3 @@ jobs:
         with:
           image-name: storage-service:1.3.0
           severity-threshold: HIGH
-        env:
-          DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -126,3 +126,5 @@ jobs:
         with:
           image-name: storage-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -208,11 +208,11 @@ func run(log *logrus.Entry) error {
 	if !ok {
 		return errors.New("missing access token")
 	}
-	insecureProxyValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION") || os.LookupEnv("INSECURE")
-	if insecureProxyValue == "true" {
-		insecureProxy = true
-	}
-
+	skipCertValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
+        insecureValue, _ := os.LookupEnv("INSECURE")
+        if skipCertValue == "true" || insecureValue == "true" {
+           insecureProxy = true
+        }
 	driverConfigParamsFile = flag.String("driver-config-params", "", "Full path to the YAML file containing the driver ConfigMap")
 	flag.Parse()
 

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -210,9 +210,9 @@ func run(log *logrus.Entry) error {
 	}
 	skipCertValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
 	insecureValue, _ := os.LookupEnv("INSECURE")
-        if skipCertValue == "true" || insecureValue == "true" {
-           insecureProxy = true
-        }
+    if skipCertValue == "true" || insecureValue == "true" {
+		insecureProxy = true
+    }
 	driverConfigParamsFile = flag.String("driver-config-params", "", "Full path to the YAML file containing the driver ConfigMap")
 	flag.Parse()
 

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -209,7 +209,7 @@ func run(log *logrus.Entry) error {
 		return errors.New("missing access token")
 	}
 	skipCertValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
-        insecureValue, _ := os.LookupEnv("INSECURE")
+	insecureValue, _ := os.LookupEnv("INSECURE")
         if skipCertValue == "true" || insecureValue == "true" {
            insecureProxy = true
         }

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -208,7 +208,7 @@ func run(log *logrus.Entry) error {
 	if !ok {
 		return errors.New("missing access token")
 	}
-	insecureProxyValue, _ := os.LookupEnv("INSECURE")
+	insecureProxyValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
 	if insecureProxyValue == "true" {
 		insecureProxy = true
 	}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -210,9 +210,9 @@ func run(log *logrus.Entry) error {
 	}
 	skipCertValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
 	insecureValue, _ := os.LookupEnv("INSECURE")
-    if skipCertValue == "true" || insecureValue == "true" {
+	if skipCertValue == "true" || insecureValue == "true" {
 		insecureProxy = true
-    }
+	}
 	driverConfigParamsFile = flag.String("driver-config-params", "", "Full path to the YAML file containing the driver ConfigMap")
 	flag.Parse()
 

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -208,7 +208,7 @@ func run(log *logrus.Entry) error {
 	if !ok {
 		return errors.New("missing access token")
 	}
-	insecureProxyValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION")
+	insecureProxyValue, _ := os.LookupEnv("SKIP_CERTIFICATE_VALIDATION") || os.LookupEnv("INSECURE")
 	if insecureProxyValue == "true" {
 		insecureProxy = true
 	}

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/openzipkin/zipkin-go v0.3.0 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,9 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/powerflex/storage_pool_cache.go
+++ b/internal/powerflex/storage_pool_cache.go
@@ -53,12 +53,13 @@ func NewStoragePoolCache(client *goscaleio.Client, cacheSize int) (*StoragePoolC
 	}, nil
 }
 
-type PowerFlexTokenGetter interface {
+// PowerFlexTokenGetter manages and retains a valid token for a PowerFlex
+type LoginTokenGetter interface {
 	GetToken(context.Context) (string, error)
 }
 
 // GetStoragePoolNameByID returns the storage pool's name from the cache via the storage pool's ID
-func (c *StoragePoolCache) GetStoragePoolNameByID(ctx context.Context, tokenGetter PowerFlexTokenGetter, id string) (string, error) {
+func (c *StoragePoolCache) GetStoragePoolNameByID(ctx context.Context, tokenGetter LoginTokenGetter, id string) (string, error) {
 	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "GetStoragePoolNameByID")
 	defer span.End()
 

--- a/internal/powerflex/storage_pool_cache.go
+++ b/internal/powerflex/storage_pool_cache.go
@@ -53,7 +53,7 @@ func NewStoragePoolCache(client *goscaleio.Client, cacheSize int) (*StoragePoolC
 	}, nil
 }
 
-// PowerFlexTokenGetter manages and retains a valid token for a PowerFlex
+// LoginTokenGetter manages and retains a valid token for a PowerFlex
 type LoginTokenGetter interface {
 	GetToken(context.Context) (string, error)
 }

--- a/internal/proxy/powerflex_handler.go
+++ b/internal/proxy/powerflex_handler.go
@@ -315,7 +315,7 @@ func (s *System) volumeCreateHandler(next http.Handler, enf *quota.RedisEnforcem
 		}
 
 		// Convert the StoragePoolID into more friendly Name.
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, body.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, body.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -493,6 +493,9 @@ func (s *System) volumeDeleteHandler(next http.Handler, enf *quota.RedisEnforcem
 				return nil, err
 			}
 			token, err := s.tk.GetToken(ctx)
+			if err != nil {
+				return nil, err
+			}
 			c.SetToken(token)
 
 			id = strings.TrimPrefix(id, "Volume::")
@@ -513,7 +516,7 @@ func (s *System) volumeDeleteHandler(next http.Handler, enf *quota.RedisEnforcem
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -669,7 +672,7 @@ func (s *System) volumeMapHandler(next http.Handler, enf *quota.RedisEnforcement
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -800,7 +803,7 @@ func (s *System) volumeUnmapHandler(next http.Handler, enf *quota.RedisEnforceme
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return


### PR DESCRIPTION
Description
Authorization insecure related entities are renamed to skip_Certificate_Validation.

The TokenGetter and the StoragePoolCache use the same PowerFlex client which sets a login token behind the scenes if none is already set. The StoragePoolCache does not use the TokenGetter to set a token so sometimes we will see a race condition when the TokenGetter is updating and the StoragePoolCache is used.

The fix is to have the StoragePoolCache use the TokenGetter to set a token before making API calls.

Added an error check in the volumeDeleteHandler and fixed the image scan check (https://github.com/aquasecurity/trivy/issues/2432).

Fixed vulnerability https://nvd.nist.gov/vuln/detail/CVE-2022-21698 by moving the Prometheus client to v1.11.1.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
(https://github.com/dell/csm/issues/368)

Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

How Has This Been Tested?
I have tested it locally for powerflex, powerscale and powermax

