### PR TITLE
[bug-382]: Fix race condition with PowerFlex login token

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -98,23 +98,33 @@ jobs:
         with:
           image-name: proxy-server:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Role Service
         uses: Azure/container-scan@v0
         with:
           image-name: role-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Tenant Service
         uses: Azure/container-scan@v0
         with:
           image-name: tenant-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan SideCar Proxy
         uses: Azure/container-scan@v0
         with:
           image-name: sidecar-proxy:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
       - name: Scan Storage Service
         uses: Azure/container-scan@v0
         with:
           image-name: storage-service:1.3.0
           severity-threshold: HIGH
+        env:
+          DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/internal/powerflex/storage_pool_cache.go
+++ b/internal/powerflex/storage_pool_cache.go
@@ -53,12 +53,13 @@ func NewStoragePoolCache(client *goscaleio.Client, cacheSize int) (*StoragePoolC
 	}, nil
 }
 
-type PowerFlexTokenGetter interface {
+// PowerFlexTokenGetter manages and retains a valid token for a PowerFlex
+type LoginTokenGetter interface {
 	GetToken(context.Context) (string, error)
 }
 
 // GetStoragePoolNameByID returns the storage pool's name from the cache via the storage pool's ID
-func (c *StoragePoolCache) GetStoragePoolNameByID(ctx context.Context, tokenGetter PowerFlexTokenGetter, id string) (string, error) {
+func (c *StoragePoolCache) GetStoragePoolNameByID(ctx context.Context, tokenGetter LoginTokenGetter, id string) (string, error) {
 	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "GetStoragePoolNameByID")
 	defer span.End()
 

--- a/internal/powerflex/storage_pool_cache.go
+++ b/internal/powerflex/storage_pool_cache.go
@@ -53,7 +53,7 @@ func NewStoragePoolCache(client *goscaleio.Client, cacheSize int) (*StoragePoolC
 	}, nil
 }
 
-// PowerFlexTokenGetter manages and retains a valid token for a PowerFlex
+// LoginTokenGetter manages and retains a valid token for a PowerFlex
 type LoginTokenGetter interface {
 	GetToken(context.Context) (string, error)
 }

--- a/internal/proxy/powerflex_handler.go
+++ b/internal/proxy/powerflex_handler.go
@@ -315,7 +315,7 @@ func (s *System) volumeCreateHandler(next http.Handler, enf *quota.RedisEnforcem
 		}
 
 		// Convert the StoragePoolID into more friendly Name.
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, body.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, body.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -493,6 +493,9 @@ func (s *System) volumeDeleteHandler(next http.Handler, enf *quota.RedisEnforcem
 				return nil, err
 			}
 			token, err := s.tk.GetToken(ctx)
+			if err != nil {
+				return nil, err
+			}
 			c.SetToken(token)
 
 			id = strings.TrimPrefix(id, "Volume::")
@@ -513,7 +516,7 @@ func (s *System) volumeDeleteHandler(next http.Handler, enf *quota.RedisEnforcem
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -669,7 +672,7 @@ func (s *System) volumeMapHandler(next http.Handler, enf *quota.RedisEnforcement
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return
@@ -800,7 +803,7 @@ func (s *System) volumeUnmapHandler(next http.Handler, enf *quota.RedisEnforceme
 			return
 		}
 
-		spName, err := s.spc.GetStoragePoolNameByID(ctx, pvName.StoragePoolID)
+		spName, err := s.spc.GetStoragePoolNameByID(ctx, s.tk, pvName.StoragePoolID)
 		if err != nil {
 			writeError(w, "powerflex", "failed to query pool name from id", http.StatusBadRequest, s.log)
 			return


### PR DESCRIPTION
# Description

The TokenGetter and the StoragePoolCache use the same PowerFlex client which sets a login token behind the scenes if none is already set. The StoragePoolCache does not use the TokenGetter to set a token so sometimes we will see a race condition when the TokenGetter is updating and the StoragePoolCache is used.

The fix is to have the StoragePoolCache use the TokenGetter to set a token before making API calls.

Also added an error check in the volumeDeleteHandler and fixes the image scan check (https://github.com/aquasecurity/trivy/issues/2432).

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/382 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Updated existing unit tests.
