### PR TITLE
Adding flag to skip selinux download

### DIFF
--- a/deploy/install.go
+++ b/deploy/install.go
@@ -80,11 +80,12 @@ var (
 // Common Rancher constants, including the required dirs for installing
 // k3s and preloading our application.
 const (
-	RancherImagesDir          = "/var/lib/rancher/k3s/agent/images"
-	RancherManifestsDir       = "/var/lib/rancher/k3s/server/manifests"
-	RancherK3sKubeConfigPath  = "/etc/rancher/k3s/k3s.yaml"
-	EnvK3sInstallSkipDownload = "INSTALL_K3S_SKIP_DOWNLOAD=true"
-	EnvK3sForceRestart        = "INSTALL_K3S_FORCE_RESTART=true"
+	RancherImagesDir             = "/var/lib/rancher/k3s/agent/images"
+	RancherManifestsDir          = "/var/lib/rancher/k3s/server/manifests"
+	RancherK3sKubeConfigPath     = "/etc/rancher/k3s/k3s.yaml"
+	EnvK3sInstallSkipDownload    = "INSTALL_K3S_SKIP_DOWNLOAD=true"
+	EnvK3sForceRestart           = "INSTALL_K3S_FORCE_RESTART=true"
+	INSTALL_K3S_SKIP_SELINUX_RPM = "INSTALL_K3S_SKIP_SELINUX_RPM=true"
 )
 
 const (
@@ -736,7 +737,7 @@ func (dp *DeployProcess) ExecuteK3sInstallScript() {
 	}
 
 	cmd := execCommand(filepath.Join(dp.tmpDir, k3SInstallScript))
-	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload, EnvK3sForceRestart)
+	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload, EnvK3sForceRestart, INSTALL_K3S_SKIP_SELINUX_RPM)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	err = cmd.Run()

--- a/deploy/install.go
+++ b/deploy/install.go
@@ -80,12 +80,12 @@ var (
 // Common Rancher constants, including the required dirs for installing
 // k3s and preloading our application.
 const (
-	RancherImagesDir             = "/var/lib/rancher/k3s/agent/images"
-	RancherManifestsDir          = "/var/lib/rancher/k3s/server/manifests"
-	RancherK3sKubeConfigPath     = "/etc/rancher/k3s/k3s.yaml"
-	EnvK3sInstallSkipDownload    = "INSTALL_K3S_SKIP_DOWNLOAD=true"
-	EnvK3sForceRestart           = "INSTALL_K3S_FORCE_RESTART=true"
-	INSTALL_K3S_SKIP_SELINUX_RPM = "INSTALL_K3S_SKIP_SELINUX_RPM=true"
+	RancherImagesDir          = "/var/lib/rancher/k3s/agent/images"
+	RancherManifestsDir       = "/var/lib/rancher/k3s/server/manifests"
+	RancherK3sKubeConfigPath  = "/etc/rancher/k3s/k3s.yaml"
+	EnvK3sInstallSkipDownload = "INSTALL_K3S_SKIP_DOWNLOAD=true"
+	EnvK3sForceRestart        = "INSTALL_K3S_FORCE_RESTART=true"
+	EnvK3sSkipSelinuxRpm      = "INSTALL_K3S_SKIP_SELINUX_RPM=true"
 )
 
 const (
@@ -737,7 +737,7 @@ func (dp *DeployProcess) ExecuteK3sInstallScript() {
 	}
 
 	cmd := execCommand(filepath.Join(dp.tmpDir, k3SInstallScript))
-	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload, EnvK3sForceRestart, INSTALL_K3S_SKIP_SELINUX_RPM)
+	cmd.Env = append(os.Environ(), EnvK3sInstallSkipDownload, EnvK3sForceRestart, EnvK3sSkipSelinuxRpm)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	err = cmd.Run()


### PR DESCRIPTION
# Description
There was an issue while installing karavi-authorization-1.4-0.x86_64.rpm, the k3s would fail to install, which is caused by trying to install k3s-selinux unsuccessfully. By adding this flag, the installation would skip the installation of k3s-selinux.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/461 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
