### PR TITLE
Integrate k3s-selinux package in the RPM airgap installer script

### DIFF
--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -52,17 +52,17 @@ then
 fi
 
 # Download SELinux packages
-if [[ ! -F $K3S_SELINUX_MICROOS]]
+if [[ ! -f $K3S_SELINUX_MICROOS ]]
 then
 	curl -kL -o $K3S_SELINUX_MICROOS https://rpm.rancher.io/k3s/latest/common/microos/noarch/k3s-selinux-0.4-1.sle.noarch.rpm
 fi
 
-if [[ ! -F $K3S_SELINUX_CENTOS7]]
+if [[ ! -f $K3S_SELINUX_CENTOS7 ]]
 then
 	curl -kL -o $K3S_SELINUX_CENTOS7 https://rpm.rancher.io/k3s/latest/common/centos/7/noarch/k3s-selinux-0.4-1.el7.noarch.rpm
 fi
 
-if [[ ! -F $K3S_SELINUX_CENTOS8]]
+if [[ ! -f $K3S_SELINUX_CENTOS8 ]]
 then
 	curl -kL -o $K3S_SELINUX_CENTOS8 https://rpm.rancher.io/k3s/latest/common/centos/8/noarch/k3s-selinux-0.4-1.el8.noarch.rpm
 fi
@@ -98,6 +98,9 @@ rm $K3S_INSTALL_SCRIPT \
 	$K3S_BINARY \
 	$K3S_IMAGES_TAR \
 	$CRED_SHIELD_IMAGES_TAR \
+	$K3S_SELINUX_MICROOS \
+	$K3S_SELINUX_CENTOS7 \
+	$K3S_SELINUX_CENTOS8 \
 	$CERT_MANAGER_IMAGES_TAR \
 	${DIST}/$CERT_MANAGER_MANIFEST \
 	${DIST}/$CERT_MANAGER_CONFIG_MANIFEST \

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -7,6 +7,9 @@ DIST=dist
 K3S_INSTALL_SCRIPT=${DIST}/k3s-install.sh
 K3S_BINARY=${DIST}/k3s
 K3S_IMAGES_TAR=${DIST}/k3s-airgap-images-$ARCH.tar
+K3S_SELINUX_MICROOS=${DIST}/k3s-microos-selinux.rpm
+K3S_SELINUX_CENTOS7=${DIST}/k3s-centos7-selinux.rpm
+K3S_SELINUX_CENTOS8=${DIST}/k3s-centos8-selinux.rpm
 
 CERT_MANAGER_IMAGES_TAR=${DIST}/cert-manager-images.tar
 CRED_SHIELD_IMAGES_TAR=${DIST}/credential-shield-images.tar
@@ -46,6 +49,22 @@ if [[ ! -f $CERT_MANAGER_MANIFEST ]]
 then
 	# Download cert-manager manifest
 	curl -kL -o  ${DIST}/$CERT_MANAGER_MANIFEST https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+fi
+
+# Download SELinux packages
+if [[ ! -F $K3S_SELINUX_MICROOS]]
+then
+	curl -kL -o $K3S_SELINUX_MICROOS https://rpm.rancher.io/k3s/latest/common/microos/noarch/k3s-selinux-0.4-1.sle.noarch.rpm
+fi
+
+if [[ ! -F $K3S_SELINUX_CENTOS7]]
+then
+	curl -kL -o $K3S_SELINUX_CENTOS7 https://rpm.rancher.io/k3s/latest/common/centos/7/noarch/k3s-selinux-0.4-1.el7.noarch.rpm
+fi
+
+if [[ ! -F $K3S_SELINUX_CENTOS8]]
+then
+	curl -kL -o $K3S_SELINUX_CENTOS8 https://rpm.rancher.io/k3s/latest/common/centos/8/noarch/k3s-selinux-0.4-1.el8.noarch.rpm
 fi
 
 # Pull all 3rd party images to ensure they exist locally.


### PR DESCRIPTION
# Description
This PR integrates the k3s-selinux package in the RPM airgap downloader script. The packages include versions for microos, centos7, and centos8.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/409|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
I have run make distclean docker dist and seen that the packages get downloaded to the associated tar file.

- [ ] Test A
- [ ] Test B
