### PR TITLE
[bug-350]: Clarify role update error messages

### DIFF
--- a/cmd/karavictl/cmd/role_create.go
+++ b/cmd/karavictl/cmd/role_create.go
@@ -35,8 +35,8 @@ const roleFlagSize = 5
 func NewRoleCreateCmd() *cobra.Command {
 	roleCreateCmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create one or more Karavi roles",
-		Long:  `Creates one or more Karavi roles`,
+		Short: "Create one or more CSM roles",
+		Long:  `Creates one or more CSM roles`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_delete.go
+++ b/cmd/karavictl/cmd/role_delete.go
@@ -30,8 +30,8 @@ import (
 func NewRoleDeleteCmd() *cobra.Command {
 	roleDeleteCmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete role",
-		Long:  `Delete role`,
+		Short: "Delete one or more CSM roles",
+		Long:  `Delete one or mroe CSM roles`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_get.go
+++ b/cmd/karavictl/cmd/role_get.go
@@ -30,8 +30,8 @@ import (
 func NewRoleGetCmd() *cobra.Command {
 	roleGetCmd := &cobra.Command{
 		Use:   "get",
-		Short: "Get role",
-		Long:  `Get role`,
+		Short: "Get CSM role",
+		Long:  `Get CSM role`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_list.go
+++ b/cmd/karavictl/cmd/role_list.go
@@ -27,8 +27,8 @@ import (
 func NewRoleListCmd() *cobra.Command {
 	roleListCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List roles",
-		Long:  `List roles`,
+		Short: "List CSM roles",
+		Long:  `List CSM roles`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_update.go
+++ b/cmd/karavictl/cmd/role_update.go
@@ -30,8 +30,8 @@ import (
 func NewRoleUpdateCmd() *cobra.Command {
 	roleUpdateCmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update the quota of one or more Karavi roles",
-		Long:  `Updates the quota of one or more Karavi roles`,
+		Short: "Update the quota of one or more CSM roles",
+		Long:  `Updates the quota of one or more CSM roles`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_update.go
+++ b/cmd/karavictl/cmd/role_update.go
@@ -86,7 +86,8 @@ func NewRoleUpdateCmd() *cobra.Command {
 
 				for _, rls := range rff.Instances() {
 					if existingRoles.Get(rls.RoleKey) == nil {
-						reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf("%s role does not exist. Try create command", rls.Name))
+						fmt.Println("here")
+						reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, "only role quota can be updated"))
 					}
 
 					err = validateRole(ctx, rls)

--- a/cmd/karavictl/cmd/role_update.go
+++ b/cmd/karavictl/cmd/role_update.go
@@ -86,7 +86,6 @@ func NewRoleUpdateCmd() *cobra.Command {
 
 				for _, rls := range rff.Instances() {
 					if existingRoles.Get(rls.RoleKey) == nil {
-						fmt.Println("here")
 						reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), fmt.Errorf(outFormat, "only role quota can be updated"))
 					}
 

--- a/cmd/karavictl/cmd/role_update.go
+++ b/cmd/karavictl/cmd/role_update.go
@@ -30,8 +30,8 @@ import (
 func NewRoleUpdateCmd() *cobra.Command {
 	roleUpdateCmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update one or more Karavi roles",
-		Long:  `Updates one or more Karavi roles`,
+		Short: "Update the quota of one or more Karavi roles",
+		Long:  `Updates the quota of one or more Karavi roles`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/karavictl/cmd/role_update_test.go
+++ b/cmd/karavictl/cmd/role_update_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 )
 
@@ -128,6 +127,9 @@ func Test_Unit_RoleUpdate(t *testing.T) {
 				osExitCalled = true
 				done <- struct{}{}
 			}
+			defer func() {
+				osExit = os.Exit
+			}()
 
 			var err error
 			go func() {
@@ -147,51 +149,4 @@ func Test_Unit_RoleUpdate(t *testing.T) {
 			}
 		})
 	}
-
-	t.Run("fail update non-quota", func(t *testing.T) {
-		// prepare mock execution of k3s command to get role data
-		execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-			cmd := exec.CommandContext(
-				context.Background(),
-				os.Args[0],
-				append([]string{
-					"-test.run=TestK3sRoleSubprocess",
-					"--",
-					name}, args...)...)
-			cmd.Env = append(os.Environ(), "WANT_GO_TEST_SUBPROCESS=1")
-
-			return cmd
-		}
-		defer func() {
-			execCommandContext = exec.CommandContext
-		}()
-
-		// prepare the karavictl command to update a role
-		cmd := NewRootCmd()
-		cmd.SetArgs([]string{"role", "update",
-			"--role=CSIBronze=powerflex=542a2d5f5122210f=newPool=9000000"})
-		var (
-			stdout bytes.Buffer
-			stderr bytes.Buffer
-		)
-		cmd.SetOutput(&stdout)
-		cmd.SetErr(&stderr)
-
-		// prepare mock execution of os.Exit()
-		done := make(chan struct{})
-		osExit = func(c int) {
-			done <- struct{}{}
-		}
-
-		// execute the karavictl command
-		go cmd.Execute()
-		<-done
-
-		// check for desired output in stderr
-		want := "only role quota can be updated"
-		got := stderr.String()
-		if !strings.Contains(got, want) {
-			t.Errorf("expected error message to contain %s, got %s", want, got)
-		}
-	})
 }

--- a/internal/role-service/roles/roles.go
+++ b/internal/role-service/roles/roles.go
@@ -17,7 +17,6 @@ package roles
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -172,7 +171,7 @@ func (j *JSON) Remove(r *Instance) error {
 	defer j.mu.Unlock()
 
 	if _, ok := j.M[r.RoleKey]; !ok {
-		return errors.New("not found")
+		return fmt.Errorf("%s not found", r.String())
 	}
 	delete(j.M, r.RoleKey)
 	return nil

--- a/internal/role-service/service.go
+++ b/internal/role-service/service.go
@@ -263,7 +263,7 @@ func (s *Service) Update(ctx context.Context, req *pb.RoleUpdateRequest) (*pb.Ro
 	}
 
 	if existingRoles.Get(roleInstance.RoleKey) == nil {
-		return nil, fmt.Errorf("%s role does not exist. Try create command", roleInstance.Name)
+		return nil, fmt.Errorf("only role quota can be updated")
 	}
 
 	s.log.Debug("Validating role")

--- a/internal/role-service/service_test.go
+++ b/internal/role-service/service_test.go
@@ -386,7 +386,7 @@ func TestServiceUpdate(t *testing.T) {
 
 	// define test input
 	tests := map[string]func(t *testing.T) (*pb.RoleUpdateRequest, role.Validator, role.Kube, checkFn){
-		"success": func(t *testing.T) (*pb.RoleUpdateRequest, role.Validator, role.Kube, checkFn) {
+		"success update quota": func(t *testing.T) (*pb.RoleUpdateRequest, role.Validator, role.Kube, checkFn) {
 			req := &pb.RoleUpdateRequest{
 				Name:        "test",
 				StorageType: "powerflex",
@@ -411,6 +411,32 @@ func TestServiceUpdate(t *testing.T) {
 			}
 
 			return req, successfulValidator{}, fakeKube{GetConfiguredRolesFn: getRolesFn}, errIsNil
+		},
+		"fail update non-quota": func(t *testing.T) (*pb.RoleUpdateRequest, role.Validator, role.Kube, checkFn) {
+			req := &pb.RoleUpdateRequest{
+				Name:        "test",
+				StorageType: "powerflex",
+				SystemId:    "542a2d5f5122210f",
+				Pool:        "silver",
+				Quota:       "9GB",
+			}
+
+			ri, err := roles.NewInstance("test", "powerflex", "542a2d5f5122210f", "bronze", "9GB")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			r := roles.NewJSON()
+			err = r.Add(ri)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			getRolesFn := func(ctx context.Context) (*roles.JSON, error) {
+				return &r, nil
+			}
+
+			return req, successfulValidator{}, fakeKube{GetConfiguredRolesFn: getRolesFn}, errIsNotNil
 		},
 		"fail validation": func(t *testing.T) (*pb.RoleUpdateRequest, role.Validator, role.Kube, checkFn) {
 			req := &pb.RoleUpdateRequest{


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

- Updates error messages of `karavictl role update` to clarify that only the quota of a role can be updated
- If a role is not found, the error message shows the `RoleKey`, the unique identifier for the role instead of just the role name
- Adds unit test to role-service for non-quota update

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/530|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
