### PR TITLE
Updated GoClient dependencies (gopowermax) to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/dell/goisilon v1.9.0
-	github.com/dell/gopowermax/v2 v2.0.0
+	github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52
 	github.com/dell/goscaleio v1.8.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.5.1
@@ -114,7 +114,7 @@ require (
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458 // indirect
-	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665
-	github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52
+	github.com/dell/gopowermax/v2 v2.0.1-0.20221110125204-19ba5b526a77
 	github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.19
 
 require (
 	github.com/alicebob/miniredis/v2 v2.17.0
-	github.com/dell/goisilon v1.9.0
+	github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665
 	github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52
-	github.com/dell/goscaleio v1.8.0
+	github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/dell/goisilon v1.9.0 h1:FFZiE71NA+cnfFqm9MYxCg8ADgYzIX969jPrFta6edE=
 github.com/dell/goisilon v1.9.0/go.mod h1:fJXHyh1JBcbsmPBquEulaNOFTpj1eEN5vISDf/UY1RQ=
-github.com/dell/gopowermax/v2 v2.0.0 h1:k4/p6ml8yHQXw8nECCwY0UriIhpcB/VPoueb80AiMTE=
-github.com/dell/gopowermax/v2 v2.0.0/go.mod h1:eJEsDN0O0nFqiSdgOXZK73Cv/LlP/+psnkyFSXLR/wI=
+github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52 h1:W4RPKU/1JnIrHxVbEAa5q7FcHwnzrA8kw/yGaw2SJTI=
+github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52/go.mod h1:m5/9UOSuhs12+CnSpytJaWC53m2i4TNJ1360w7gChmc=
 github.com/dell/goscaleio v1.8.0 h1:a5wxvUwqvsr1KGUoHkY5Ol1jsNkQ8VKyTGdFeI5RVLQ=
 github.com/dell/goscaleio v1.8.0/go.mod h1:TJbQ8N6hk48w5rEyBa+pRtrRJbPVnCTsYM3mmUyPNaY=
 github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=
@@ -789,8 +789,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/go.sum
+++ b/go.sum
@@ -120,12 +120,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:1iy2qD6JEhHKKhUOA9IWs7mjco7lnw2qx8FsRI2wirE=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
-github.com/dell/goisilon v1.9.0 h1:FFZiE71NA+cnfFqm9MYxCg8ADgYzIX969jPrFta6edE=
-github.com/dell/goisilon v1.9.0/go.mod h1:fJXHyh1JBcbsmPBquEulaNOFTpj1eEN5vISDf/UY1RQ=
+github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665 h1:a78mtVQYNB+wgiUI2oaIvhJAwtyv3GFQcMXHihtXCeA=
+github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665/go.mod h1:fJXHyh1JBcbsmPBquEulaNOFTpj1eEN5vISDf/UY1RQ=
 github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52 h1:W4RPKU/1JnIrHxVbEAa5q7FcHwnzrA8kw/yGaw2SJTI=
 github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52/go.mod h1:m5/9UOSuhs12+CnSpytJaWC53m2i4TNJ1360w7gChmc=
-github.com/dell/goscaleio v1.8.0 h1:a5wxvUwqvsr1KGUoHkY5Ol1jsNkQ8VKyTGdFeI5RVLQ=
-github.com/dell/goscaleio v1.8.0/go.mod h1:TJbQ8N6hk48w5rEyBa+pRtrRJbPVnCTsYM3mmUyPNaY=
+github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad h1:N9BUiu8ZkCt+k19hRTj1QPeSltmw0Tty2KdlpL+MH8A=
+github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad/go.mod h1:TJbQ8N6hk48w5rEyBa+pRtrRJbPVnCTsYM3mmUyPNaY=
 github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=
 github.com/docker/distribution v2.8.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.18+incompatible h1:SN84VYXTBNGn92T/QwIRPlum9zfemfitN7pbsp26WSc=

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665 h1:a78mtVQYNB+wgiUI2oaIvhJAwtyv3GFQcMXHihtXCeA=
 github.com/dell/goisilon v1.9.1-0.20221109063552-faabba2ba665/go.mod h1:fJXHyh1JBcbsmPBquEulaNOFTpj1eEN5vISDf/UY1RQ=
-github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52 h1:W4RPKU/1JnIrHxVbEAa5q7FcHwnzrA8kw/yGaw2SJTI=
-github.com/dell/gopowermax/v2 v2.0.1-0.20221109120540-a5532f923a52/go.mod h1:m5/9UOSuhs12+CnSpytJaWC53m2i4TNJ1360w7gChmc=
+github.com/dell/gopowermax/v2 v2.0.1-0.20221110125204-19ba5b526a77 h1:ddQ13jjKJa1wr1B38GR4C+kIFFhR5jT9pSq1yo8/7JA=
+github.com/dell/gopowermax/v2 v2.0.1-0.20221110125204-19ba5b526a77/go.mod h1:m5/9UOSuhs12+CnSpytJaWC53m2i4TNJ1360w7gChmc=
 github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad h1:N9BUiu8ZkCt+k19hRTj1QPeSltmw0Tty2KdlpL+MH8A=
 github.com/dell/goscaleio v1.8.1-0.20221028175854-ea08d8f5e7ad/go.mod h1:TJbQ8N6hk48w5rEyBa+pRtrRJbPVnCTsYM3mmUyPNaY=
 github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
Updated goclient dependencies (gopowermax, goisilon, and goscaleio) to latest commit IDs in go.mod file

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|dell/csm#491 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Powermax Authorization nightly e2e test-
6 scenarios [32m6 passed]0m)
51 steps ([32m51 passed]0m)
7m57.506530363s
2022/11/14 21:09:00 Volume test finished
--- PASS: TestVolume (477.53s)

- [x] Powerscale Authorization nightly e2e test-
3 scenarios ([32m3 passed]0m)
27 steps ([32m27 passed]0m)
7m55.753261784s
2022/11/15 21:09:49 Volume test finished
--- PASS: TestVolume (475.77s)