### PR TITLE
Fix #580: change k3s to /usr/local/bin/k3s

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 # Bowen Jiang (bjiang27)
 # Isaias Martinez (isaiasA1)
 # Arnchie qu (arnchiequ-dell)
+# Luna Xu (xuluna)
 
 # for all files:
-* @gallacher @tdawe @alikdell @atye @hoppea2 @coulof @shaynafinocchiaro @sharmilarama @EvgenyUglov @bjiang27 @isaiasA1 @arnchiequ-dell
+* @gallacher @tdawe @alikdell @atye @hoppea2 @coulof @shaynafinocchiaro @sharmilarama @EvgenyUglov @bjiang27 @isaiasA1 @arnchiequ-dell @xuluna

--- a/deploy/airgap-prepare.sh
+++ b/deploy/airgap-prepare.sh
@@ -1,17 +1,16 @@
-:'
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
- 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-'
 #!/bin/bash -x
+
+# Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ARCH=amd64
 SIDECAR_DOCKER_TAG=1.5.0

--- a/policies/policy-install.sh
+++ b/policies/policy-install.sh
@@ -13,9 +13,10 @@
 
 set -x
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
+K3S=/usr/local/bin/k3s
 
 counter=1
-while [[ $(k3s kubectl get namespaces | grep karavi | wc -l) -ne 1 ]]
+while [[ $($K3S kubectl get namespaces | grep karavi | wc -l) -ne 1 ]]
 do 
     if [[ "$counter" -eq 30 ]]
     then
@@ -29,22 +30,22 @@ done
 
 cd "$(dirname "$0")"
 
-if [[ $(k3s kubectl get secret karavi-storage-secret -n karavi | grep karavi-storage-secret | wc -l) -ne 1 ]]
+if [[ $($K3S kubectl get secret karavi-storage-secret -n karavi | grep karavi-storage-secret | wc -l) -ne 1 ]]
 then
     echo "Creating karavi storage secret"
-    k3s kubectl apply -f ./karavi-storage-secret.yaml
+    $K3S kubectl apply -f ./karavi-storage-secret.yaml
 fi
 
-if [[ $(k3s kubectl get configmap common -n karavi | grep common | wc -l) -ne 1 ]]
+if [[ $($K3S kubectl get configmap common -n karavi | grep common | wc -l) -ne 1 ]]
 then
-    k3s kubectl create configmap common -n karavi --from-file=./common.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
+    $K3S kubectl create configmap common -n karavi --from-file=./common.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
 fi
-k3s kubectl create configmap powermax-volumes-create -n karavi --from-file=./volumes_powermax_create.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap powerscale-volumes-create -n karavi --from-file=./volumes_powerscale_create.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap volumes-unmap -n karavi --from-file=./volumes_unmap.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap volumes-map -n karavi --from-file=./volumes_map.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap powerflex-urls -n karavi --from-file=./url.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap powermax-urls -n karavi --from-file=./powermax_url.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
-k3s kubectl create configmap powerscale-urls -n karavi --from-file=./powerscale_url.rego --save-config --dry-run=client -o yaml | k3s kubectl apply -f -
+$K3S kubectl create configmap powermax-volumes-create -n karavi --from-file=./volumes_powermax_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerscale-volumes-create -n karavi --from-file=./volumes_powerscale_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-create -n karavi --from-file=./volumes_create.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-delete -n karavi --from-file=./volumes_delete.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-unmap -n karavi --from-file=./volumes_unmap.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap volumes-map -n karavi --from-file=./volumes_map.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerflex-urls -n karavi --from-file=./url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powermax-urls -n karavi --from-file=./powermax_url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -
+$K3S kubectl create configmap powerscale-urls -n karavi --from-file=./powerscale_url.rego --save-config --dry-run=client -o yaml | $K3S kubectl apply -f -

--- a/scripts/init_opa.sh
+++ b/scripts/init_opa.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 docker run -p 8181:8181 --rm -d openpolicyagent/opa \
 	run --server --log-level debug


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
Fix issue 580 that installation of RPM errors out on k3s command not found. The PR changed the installation script to default location of k3s install /usr/local/bin/k3s.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/580 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
I have made a package and move it to a new machine which PATH doesn't include /usr/local/bin. Manual installation of karavi-authorization with the package was performed successfully.
