### PR TITLE
[feature-582]: Only retrieve all PowerMax systems when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-installer:
 
 .PHONY: rpm
 rpm:
-	docker run \
+	docker run --rm \
 		-v $$PWD/deploy/rpm/pkg:/srv/pkg \
 		-v $$PWD/bin/deploy:/home/builder/rpm/deploy \
 		-v $$PWD/deploy/rpm:/home/builder/rpm \

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -287,22 +287,6 @@ func NewStorageCreateCmd() *cobra.Command {
 						errAndExit(err)
 					}
 
-					/*var powermaxSymmetrix []*types.Symmetrix
-
-					symmetrixIDList, err := pmClient.GetSymmetrixIDList(ctx)
-					if err != nil {
-						errAndExit(err)
-					}
-					for _, s := range symmetrixIDList.SymmetrixIDs {
-						symmetrix, err := pmClient.GetSymmetrixByID(ctx, s)
-						if err != nil {
-							errAndExit(err)
-						}
-						if strings.Contains(symmetrix.Model, "PowerMax") || strings.Contains(symmetrix.Model, "VMAX") {
-							powermaxSymmetrix = append(powermaxSymmetrix, symmetrix)
-						}
-					}*/
-
 					symmetrix, err := pmClient.GetSymmetrixByID(ctx, input.SystemID)
 					if err != nil {
 						errAndExit(err)
@@ -319,28 +303,6 @@ func NewStorageCreateCmd() *cobra.Command {
 							Insecure: input.ArrayInsecure,
 						}
 					}
-
-					/*createStorageFunc := func(id string) {
-						tempStorage[id] = System{
-							User:     input.User,
-							Password: input.Password,
-							Endpoint: input.Endpoint,
-							Insecure: input.ArrayInsecure,
-						}
-					}
-
-					for _, p := range powermaxSymmetrix {
-						storageID := strings.Trim(SystemID{Value: p.SymmetrixID}.String(), "\"")
-						if input.SystemID != "" {
-							if len(sysIDs) > 0 {
-								if contains(p.SymmetrixID, sysIDs) {
-									createStorageFunc(storageID)
-								}
-								continue
-							}
-						}
-						createStorageFunc(storageID)
-					}*/
 
 				case powerscale:
 					tempStorage = storage[powerscale]

--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -29,7 +29,6 @@ import (
 
 	pscale "github.com/dell/goisilon"
 	pmax "github.com/dell/gopowermax/v2"
-	types "github.com/dell/gopowermax/v2/types/v100"
 	"github.com/dell/goscaleio"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -288,7 +287,7 @@ func NewStorageCreateCmd() *cobra.Command {
 						errAndExit(err)
 					}
 
-					var powermaxSymmetrix []*types.Symmetrix
+					/*var powermaxSymmetrix []*types.Symmetrix
 
 					symmetrixIDList, err := pmClient.GetSymmetrixIDList(ctx)
 					if err != nil {
@@ -302,9 +301,26 @@ func NewStorageCreateCmd() *cobra.Command {
 						if strings.Contains(symmetrix.Model, "PowerMax") || strings.Contains(symmetrix.Model, "VMAX") {
 							powermaxSymmetrix = append(powermaxSymmetrix, symmetrix)
 						}
+					}*/
+
+					symmetrix, err := pmClient.GetSymmetrixByID(ctx, input.SystemID)
+					if err != nil {
+						errAndExit(err)
+					}
+					if !strings.Contains(symmetrix.Model, "PowerMax") && !strings.Contains(symmetrix.Model, "VMAX") {
+						errAndExit(fmt.Errorf("unsupported model %s", symmetrix.Model))
 					}
 
-					createStorageFunc := func(id string) {
+					if contains(symmetrix.SymmetrixID, sysIDs) {
+						tempStorage[strings.Trim(SystemID{Value: symmetrix.SymmetrixID}.String(), "\"")] = System{
+							User:     input.User,
+							Password: input.Password,
+							Endpoint: input.Endpoint,
+							Insecure: input.ArrayInsecure,
+						}
+					}
+
+					/*createStorageFunc := func(id string) {
 						tempStorage[id] = System{
 							User:     input.User,
 							Password: input.Password,
@@ -324,7 +340,7 @@ func NewStorageCreateCmd() *cobra.Command {
 							}
 						}
 						createStorageFunc(storageID)
-					}
+					}*/
 
 				case powerscale:
 					tempStorage = storage[powerscale]


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

- Refactor `karavictl storage create` to retrieve all PowerMax systems only when necessary.
- Add the `--rm` flag to the `rpm` make target to remove the rpmbuild/centos7 container.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/582 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Existing unit tests since this is a refactor change.
