### PR TITLE
Volume delete & Storage Response check.

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -693,6 +693,8 @@ func volumesHandler(roleServ *roleClientService, storageServ *storageClientServi
 									volumeMap[sysID][splitStr[1]] = splitStr[1]
 								}
 							}
+						}
+						for volKey := range res {
 							if strings.Contains(volKey, "deleted") {
 								splitStr := strings.Split(volKey, ":")
 								//example : vol:k8s-cb89d36285:deleted
@@ -738,14 +740,13 @@ func volumesHandler(roleServ *roleClientService, storageServ *storageClientServi
 			}
 
 			storageResp, err = storageServ.storageClient.GetPowerflexVolumes(r.Context(), powerflexVolumesRequest)
-
-			volumeList = append(volumeList, storageResp.Volume...)
-
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				log.WithError(err).Println("unable to get powerflex volumes")
 				return
 			}
+
+			volumeList = append(volumeList, storageResp.Volume...)
 
 			log.Printf("Volume Details for System ID: %s\n %v", sysID, storageResp.String())
 		}


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
This fixes a defect where deleted volumes are getting pulled, and a Bad Gateway Error caused by misplaced command.

# GitHub Issues
List the GitHub issues impacted by this PR: 

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/408 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Tested on my local system with powerflex: 
2023/02/13 17:32:28 Starting volume test
Feature: Karavi Authorization
  As a consumer of the Karavi Authorization
  I want to test karavi authorization
  So that they are known to work

  Scenario: Show Volumes                                                            # features/volume.feature:7
    Given Karavi Authorization is available and configured                          # <autogenerated>:1 -> *feature
    And I have <storageclass>                                                       # <autogenerated>:1 -> *feature
    When I create a  <pvc> request from <storageclass> with storage capacity <size> # <autogenerated>:1 -> *feature
    Then I can request a pod to consume <pvc>                                       # <autogenerated>:1 -> *feature
    And <pvc> is bound to storage                                                   # <autogenerated>:1 -> *feature
    And volume is created in backend storage                                        # <autogenerated>:1 -> *feature
    And dellctl volume list                                                         # <autogenerated>:1 -> *feature
    And I delete the pod and <pvc>                                                  # <autogenerated>:1 -> *feature
    And <pvc> is deleted from kubernetes                                            # <autogenerated>:1 -> *feature
    And volume is deleted from backend storage                                      # <autogenerated>:1 -> *feature

    Examples:
      | storageclass   | size  | pvc          |
      | "vxflexos-xfs" | "2Mi" | "pineapple"  |
      | "vxflexos-xfs" | "4Mi" | "greenapple" |
      | "vxflexos-xfs" | "1Mi" | "redapple"   |

3 scenarios (3 passed)
30 steps (30 passed)
2m15.085141885s
2023/02/13 17:34:43 Volume test finished
PASS
status 0
ok      karavi-testing/karavi-authorization/auth-test   135.154s
