### PR TITLE
[feature-582]: Verbose error handling in volumes hanlder

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -750,11 +750,11 @@ func volumesHandler(roleServ *roleClientService, storageServ *storageClientServi
 
 			storageResp, err = storageServ.storageClient.GetPowerflexVolumes(r.Context(), powerflexVolumesRequest)
 			if err != nil {
+				log.WithError(err).Println("getting powerflex volumes")
 				w.WriteHeader(http.StatusInternalServerError)
 				if jsonErr := web.JSONErrorResponse(w, fmt.Errorf("getting powerflex volumes: %v", err)); jsonErr != nil {
 					log.WithError(jsonErr).Println("error creating json response")
 				}
-				log.WithError(err).Println("getting powerflex volumes")
 				return
 			}
 


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

This PR updates error handling in the `volumesHandler` to be more verbose.

- Write an error body to the client if there is an error calling the storage service
- Have separate error and response checks when calling redis for volume data
- If there is an error writing a json error response to the client, we capture that in the logs

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/582 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Existing tests since there is no new functionality.
