### PR TITLE
CSM Authorization karavictl requires an admin token

### DIFF
--- a/cmd/karavictl/cmd/generate_admin.go
+++ b/cmd/karavictl/cmd/generate_admin.go
@@ -24,8 +24,8 @@ import (
 func NewAdminCmd() *cobra.Command {
 	adminCmd := &cobra.Command{
 		Use:   "admin",
-		Short: "Generate admin token for use with Karavi",
-		Long:  `Generate admin token for use with Karavi`,
+		Short: "Generate admin token for use with CSM Authorization",
+		Long:  `Generate admin token for use with CSM Authorization`,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Usage()
 			if err != nil {

--- a/cmd/karavictl/cmd/generate_admin.go
+++ b/cmd/karavictl/cmd/generate_admin.go
@@ -1,0 +1,40 @@
+// Copyright © 2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewAdminCmd creates a new admin token command
+func NewAdminCmd() *cobra.Command {
+	adminCmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Generate admin token for use with Karavi",
+		Long:  `Generate admin token for use with Karavi`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Usage()
+			if err != nil {
+				reportErrorAndExit(JSONOutput, os.Stderr, err)
+			}
+			os.Exit(1)
+		},
+	}
+
+	adminCmd.AddCommand(NewAdminTokenCmd())
+	return adminCmd
+}

--- a/cmd/karavictl/cmd/generate_admin_token.go
+++ b/cmd/karavictl/cmd/generate_admin_token.go
@@ -28,7 +28,7 @@ import (
 var (
 	refreshTokenTTL int64
 	accessTokenTTL  int64
-	password        string
+	secret          string
 )
 
 // NewAdminTokenCmd creates a new token command
@@ -66,18 +66,18 @@ func NewAdminTokenCmd() *cobra.Command {
 				accessTokenTTL = int64(30 * time.Minute)
 			}
 
-			password, err := cmd.Flags().GetString("password")
+			secret, err := cmd.Flags().GetString("jwt-signing-secret")
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 				return err
 			}
 
 			// If the password was not provided...
-			prompt := fmt.Sprintf("Enter password: ")
+			prompt := fmt.Sprintf("Enter JWT Signing Secret: ")
 			// If the password was not provided...
-			if pf := cmd.Flags().Lookup("password"); !pf.Changed {
+			if pf := cmd.Flags().Lookup("jwt-signing-secret"); !pf.Changed {
 				// Get password from stdin
-				readPassword(cmd.ErrOrStderr(), prompt, &password)
+				readPassword(cmd.ErrOrStderr(), prompt, &secret)
 			}
 
 			tm := jwx.NewTokenManager(jwx.HS256)
@@ -86,7 +86,7 @@ func NewAdminTokenCmd() *cobra.Command {
 				AdminName:         adminName,
 				Subject:           "admin",
 				Roles:             nil,
-				JWTSigningSecret:  password,
+				JWTSigningSecret:  secret,
 				RefreshExpiration: time.Duration(refreshTokenTTL),
 				AccessExpiration:  time.Duration(accessTokenTTL),
 			})
@@ -105,7 +105,7 @@ func NewAdminTokenCmd() *cobra.Command {
 	}
 
 	adminTokenCmd.Flags().StringP("name", "n", "", "Admin name")
-	adminTokenCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
+	adminTokenCmd.Flags().StringP("jwt-signing-secret", "s", "", "Specify JWT signing secret, or omit to use stdin")
 	adminTokenCmd.Flags().Duration("refresh-token-expiration", 30*24*time.Hour, "Expiration time of the refresh token, e.g. 48h")
 	adminTokenCmd.Flags().Duration("access-token-expiration", time.Minute, "Expiration time of the access token, e.g. 1m30s")
 	return adminTokenCmd

--- a/cmd/karavictl/cmd/generate_admin_token.go
+++ b/cmd/karavictl/cmd/generate_admin_token.go
@@ -31,7 +31,7 @@ var (
 	password        string
 )
 
-// NewGenerateAdminTokenCmd creates a new token command
+// NewAdminTokenCmd creates a new token command
 func NewAdminTokenCmd() *cobra.Command {
 	adminTokenCmd := &cobra.Command{
 		Use:   "token",

--- a/cmd/karavictl/cmd/generate_admin_token.go
+++ b/cmd/karavictl/cmd/generate_admin_token.go
@@ -1,0 +1,109 @@
+// Copyright © 2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"karavi-authorization/internal/token"
+	"karavi-authorization/internal/token/jwx"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	refreshTokenTTL int64
+	accessTokenTTL  int64
+	password        string
+)
+
+// NewGenerateAdminTokenCmd creates a new token command
+func NewAdminTokenCmd() *cobra.Command {
+	adminTokenCmd := &cobra.Command{
+		Use:   "token",
+		Short: "Generate tokens for a admin.",
+		Long:  `Generates tokens for a admin.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			adminName, err := cmd.Flags().GetString("name")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return err
+			}
+			refExpTime, err := cmd.Flags().GetDuration("refresh-token-expiration")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return err
+			}
+			if refExpTime <= 0 {
+				refreshTokenTTL = int64(24 * time.Hour)
+			}
+
+			accExpTime, err := cmd.Flags().GetDuration("access-token-expiration")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return err
+			}
+			if accExpTime <= 0 {
+				accessTokenTTL = int64(30 * time.Minute)
+			}
+
+			password, err := cmd.Flags().GetString("password")
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return err
+			}
+
+			// If the password was not provided...
+			prompt := fmt.Sprintf("Enter password: ")
+			// If the password was not provided...
+			if pf := cmd.Flags().Lookup("password"); !pf.Changed {
+				// Get password from stdin
+				readPassword(cmd.ErrOrStderr(), prompt, &password)
+			}
+
+			tm := jwx.NewTokenManager(jwx.HS256)
+			// Generate the token.
+			s, err := token.CreateAdminSecret(tm, token.Config{
+				AdminName:         adminName,
+				Subject:           "admin",
+				Roles:             nil,
+				JWTSigningSecret:  password,
+				RefreshExpiration: time.Duration(refreshTokenTTL),
+				AccessExpiration:  time.Duration(accessTokenTTL),
+			})
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return nil
+			}
+
+			err = JSONOutput(cmd.OutOrStdout(), &s)
+			if err != nil {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
+				return nil
+			}
+			return nil
+		},
+	}
+
+	adminTokenCmd.Flags().StringP("name", "t", "", "Admin name")
+	adminTokenCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
+	adminTokenCmd.Flags().Duration("refresh-token-expiration", 30*24*time.Hour, "Expiration time of the refresh token, e.g. 48h")
+	adminTokenCmd.Flags().Duration("access-token-expiration", time.Minute, "Expiration time of the access token, e.g. 1m30s")
+	if err := adminTokenCmd.MarkFlagRequired("name"); err != nil {
+		reportErrorAndExit(JSONOutput, adminTokenCmd.ErrOrStderr(), err)
+	}
+	return adminTokenCmd
+}

--- a/cmd/karavictl/cmd/generate_admin_token.go
+++ b/cmd/karavictl/cmd/generate_admin_token.go
@@ -15,9 +15,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"karavi-authorization/internal/token"
 	"karavi-authorization/internal/token/jwx"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -42,6 +44,10 @@ func NewAdminTokenCmd() *cobra.Command {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
 				return err
 			}
+			if strings.TrimSpace(adminName) == "" {
+				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), errors.New("empty admin name not allowed"))
+			}
+
 			refExpTime, err := cmd.Flags().GetDuration("refresh-token-expiration")
 			if err != nil {
 				reportErrorAndExit(JSONOutput, cmd.ErrOrStderr(), err)
@@ -98,12 +104,9 @@ func NewAdminTokenCmd() *cobra.Command {
 		},
 	}
 
-	adminTokenCmd.Flags().StringP("name", "t", "", "Admin name")
+	adminTokenCmd.Flags().StringP("name", "n", "", "Admin name")
 	adminTokenCmd.Flags().StringP("password", "p", "", "Specify password, or omit to use stdin")
 	adminTokenCmd.Flags().Duration("refresh-token-expiration", 30*24*time.Hour, "Expiration time of the refresh token, e.g. 48h")
 	adminTokenCmd.Flags().Duration("access-token-expiration", time.Minute, "Expiration time of the access token, e.g. 1m30s")
-	if err := adminTokenCmd.MarkFlagRequired("name"); err != nil {
-		reportErrorAndExit(JSONOutput, adminTokenCmd.ErrOrStderr(), err)
-	}
 	return adminTokenCmd
 }

--- a/cmd/karavictl/cmd/generate_admin_token_test.go
+++ b/cmd/karavictl/cmd/generate_admin_token_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestGenerateAdminToken(t *testing.T) {
+	afterFn := func() {
+		JSONOutput = jsonOutput
+		osExit = os.Exit
+	}
+	t.Run("it requests creation of admin token", func(t *testing.T) {
+		defer afterFn()
+		JSONOutput = func(w io.Writer, _ interface{}) error {
+			return nil
+		}
+		osExit = func(code int) {
+		}
+		var gotOutput bytes.Buffer
+
+		cmd := NewRootCmd()
+		cmd.SetOutput(&gotOutput)
+		cmd.SetArgs([]string{"admin", "token", "--name", "testname", "-p", "password"})
+		cmd.Execute()
+
+		if len(gotOutput.Bytes()) != 0 {
+			t.Errorf("expected zero output but got %q", string(gotOutput.Bytes()))
+		}
+	})
+	t.Run("it requires a valid name argument", func(t *testing.T) {
+		defer afterFn()
+		var gotCode int
+		done := make(chan struct{})
+		osExit = func(code int) {
+			gotCode = code
+			done <- struct{}{}
+			done <- struct{}{} // we can't let this function return
+		}
+
+		var gotOutput bytes.Buffer
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetErr(&gotOutput)
+		rootCmd.SetArgs([]string{"admin", "token"})
+		go rootCmd.Execute()
+		<-done
+
+		wantCode := 1
+		if gotCode != wantCode {
+			t.Errorf("got exit code %d, want %d", gotCode, wantCode)
+		}
+		var gotErr CommandError
+		if err := json.NewDecoder(&gotOutput).Decode(&gotErr); err != nil {
+			t.Fatal(err)
+		}
+		wantErrMsg := "empty admin name not allowed"
+		if gotErr.ErrorMsg != wantErrMsg {
+			t.Errorf("got err %q, want %q", gotErr.ErrorMsg, wantErrMsg)
+		}
+	})
+}

--- a/cmd/karavictl/cmd/generate_admin_token_test.go
+++ b/cmd/karavictl/cmd/generate_admin_token_test.go
@@ -38,7 +38,7 @@ func TestGenerateAdminToken(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"admin", "token", "--name", "testname", "-p", "password"})
+		cmd.SetArgs([]string{"admin", "token", "--name", "testname", "-s", "password"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -57,6 +57,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(NewClusterInfoCmd())
 	rootCmd.AddCommand(NewGenerateCmd())
 	rootCmd.AddCommand(NewStorageCmd())
+	rootCmd.AddCommand(NewAdminCmd())
 	return rootCmd
 }
 

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/token/generate.go
+++ b/internal/token/generate.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/token/generate.go
+++ b/internal/token/generate.go
@@ -59,3 +59,22 @@ func Create(tm Manager, cfg Config) (Pair, error) {
 
 	return tm.NewPair(cfg)
 }
+
+// CreateAdminSecret returns a pair of created tokens for
+// CSM Authorization admin.
+func CreateAdminSecret(tm Manager, cfg Config) (string, error) {
+	tp, err := Create(tm, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	accessTokenEnc := base64.StdEncoding.EncodeToString([]byte(tp.Access))
+	refreshTokenEnc := base64.StdEncoding.EncodeToString([]byte(tp.Refresh))
+
+	ret := fmt.Sprintf(`
+  access: %s
+  refresh: %s
+`, accessTokenEnc, refreshTokenEnc)
+
+	return ret, nil
+}

--- a/internal/token/generate_test.go
+++ b/internal/token/generate_test.go
@@ -150,6 +150,16 @@ func testBuildTokenConfig() token.Config {
 		AccessExpiration:  time.Minute,
 	}
 }
+func testBuildAdminTokenConfig() token.Config {
+	return token.Config{
+		AdminName:         "admin",
+		Subject:           "admin",
+		Roles:             nil,
+		JWTSigningSecret:  secret,
+		RefreshExpiration: time.Hour,
+		AccessExpiration:  time.Minute,
+	}
+}
 
 func testDecodeJWX(t *testing.T, token string) error {
 	t.Helper()
@@ -160,4 +170,57 @@ func testDecodeJWX(t *testing.T, token string) error {
 	}
 
 	return nil
+}
+
+func TestCreateAdminSecret(t *testing.T) {
+	t.Run("it creates a admin token", func(t *testing.T) {
+		cfg := testBuildAdminTokenConfig()
+
+		tests := []struct {
+			tmName string
+			tm     token.Manager
+		}{
+			{
+				"jwx",
+				jwx.NewTokenManager(jwx.HS256),
+			},
+		}
+
+		for _, test := range tests {
+			t.Logf("Using Manager: %s", test.tmName)
+			got, err := token.CreateAdminSecret(test.tm, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Contains([]byte(got), []byte("access")) {
+				t.Errorf("got %q, want something access: like", got)
+			}
+		}
+	})
+
+	t.Run("it requires a non-blank secret", func(t *testing.T) {
+		cfg := testBuildAdminTokenConfig()
+		cfg.JWTSigningSecret = "  "
+
+		tests := []struct {
+			tmName string
+			tm     token.Manager
+		}{
+			{
+				"jwx",
+				jwx.NewTokenManager(jwx.HS256),
+			},
+		}
+
+		for _, test := range tests {
+			t.Logf("Using Manager: %s", test.tmName)
+			_, err := token.CreateAdminSecret(test.tm, cfg)
+
+			want := token.ErrBlankSecretNotAllowed
+			if got := err; got != want {
+				t.Errorf("got err = %+v, want %+v", got, want)
+			}
+		}
+	})
 }

--- a/internal/token/generate_test.go
+++ b/internal/token/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/token/jwx/jwx.go
+++ b/internal/token/jwx/jwx.go
@@ -171,19 +171,34 @@ func (t *Token) Claims() (token.Claims, error) {
 
 func tokenFromConfig(cfg token.Config) (jwt.Token, error) {
 	t := jwt.New()
-	err := t.Set(jwt.IssuerKey, "com.dell.karavi")
+	err := t.Set(jwt.IssuerKey, "com.dell.csm")
 	if err != nil {
 		return nil, err
 	}
 
-	err = t.Set(jwt.AudienceKey, "karavi")
+	err = t.Set(jwt.AudienceKey, "csm")
 	if err != nil {
 		return nil, err
 	}
 
-	err = t.Set(jwt.SubjectKey, "karavi-tenant")
-	if err != nil {
-		return nil, err
+	if cfg.Subject == "admin" {
+		err = t.Set(jwt.SubjectKey, "csm-admin")
+		if err != nil {
+			return nil, err
+		}
+		err = t.Set("group", cfg.AdminName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = t.Set(jwt.SubjectKey, "csm-tenant")
+		if err != nil {
+			return nil, err
+		}
+		err = t.Set("group", cfg.Tenant)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = t.Set(jwt.ExpirationKey, time.Now().Add(cfg.AccessExpiration).Unix())
@@ -192,11 +207,6 @@ func tokenFromConfig(cfg token.Config) (jwt.Token, error) {
 	}
 
 	err = t.Set("roles", strings.Join(cfg.Roles, ","))
-	if err != nil {
-		return nil, err
-	}
-
-	err = t.Set("group", cfg.Tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/token/jwx/jwx.go
+++ b/internal/token/jwx/jwx.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -44,6 +44,8 @@ type Pair struct {
 // Config contains configurable options when creating tokens.
 type Config struct {
 	Tenant            string
+	AdminName         string
+	Subject           string
 	Roles             []string
 	JWTSigningSecret  string
 	RefreshExpiration time.Duration


### PR DESCRIPTION
<!--
Copyright (c) 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  #https://github.com/dell/csm/issues/725 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] karavictl admin token --name Test --jwt-signing-secret secret
      access: XlKaGJHY2lPaUpJVXpJMU5pSXNJ
      refresh: ZXlKaGJHY2lPaUpJVXpJMU5pSXNJb
- [x] karavi-authorization]# karavictl admin token --name 
                        Error: flag needs an argument: --name
                        Usage:
                        karavictl admin token [flags]
                        
                        Flags:
                              --access-token-expiration duration    Expiration time of the access token, e.g. 1m30s (default 1m0s)
                          -h, --help                                help for token
                          -n, --name string                         Admin name
                          -p, --password string                     Specify password, or omit to use stdin
                              --refresh-token-expiration duration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
                        
                        Global Flags:
                              --config string   config file (default is $HOME/.karavictl.yaml)
                        
                        flag needs an argument: --name

- [x] karavictl admin token --name Test 
Enter JWT Signing Secret:

