### PR TITLE
[bug-787]: Write status code to csi-powerscale

### DIFF
--- a/internal/web/json_response.go
+++ b/internal/web/json_response.go
@@ -63,6 +63,8 @@ func PowerScaleJSONErrorResponse(w http.ResponseWriter, code int, psErr error) e
 			},
 		},
 	}
+
+	w.WriteHeader(code)
 	err := json.NewEncoder(w).Encode(&errBody)
 	if err != nil {
 		log.Println("Failed to encode error response", err)

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -138,6 +138,8 @@ func AuthMW(log *logrus.Entry, tm token.Manager) Middleware {
 				var claims token.Claims
 				parsedToken, err := tm.ParseWithClaims(tkn, JWTSigningSecret, &claims)
 				if err != nil {
+					log.Errorf("validating token: %v", err)
+
 					fwd := ForwardedHeader(r)
 					pluginID := NormalizePluginID(fwd["by"])
 


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

- Write the status code back to the driver for csi-powerscale
- Log the error when validating the access token

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/787|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Added unit test for failed token validation for csi-powerscale.
