### PR TITLE
[feature-743]: Remove busybox from RPM

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -460,17 +460,3 @@ spec:
   - protocol: TCP
     port: 8081
     targetPort: 8081
----
-# busybox container is only here to pull in busybox as a dependency
-apiVersion: v1
-kind: Pod
-metadata:
-  name: busybox1
-  labels:
-    app: busybox1
-spec:
-  containers:
-  - name: busybox
-    image: docker.io/busybox:latest
-    
-

--- a/internal/proxy/role_handler.go
+++ b/internal/proxy/role_handler.go
@@ -38,7 +38,7 @@ func NewRoleHandler(log *logrus.Entry, client pb.RoleServiceClient) *RoleHandler
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle(web.ProxyRolesPath, web.Adapt(web.HandlerWithError(th.roleHandler), web.TelemetryMW("role_handler", log)))
+	mux.Handle(web.ProxyRolesPath, web.Adapt(web.HandlerWithError(th.roleHandler), web.TelemetryMW("roleHandler", log)))
 	th.mux = mux
 
 	return th

--- a/internal/proxy/tenant_handler.go
+++ b/internal/proxy/tenant_handler.go
@@ -41,11 +41,11 @@ func NewTenantHandler(log *logrus.Entry, client pb.TenantServiceClient) *TenantH
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle(web.ProxyTenantPath, web.Adapt(web.HandlerWithError(th.tenantHandler), web.TelemetryMW("tenant_handler", log)))
-	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "bind"), web.Adapt(web.HandlerWithError(th.bindRoleHandler), web.TelemetryMW("tenant_bind_role_handler", log)))
-	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "unbind"), web.Adapt(web.HandlerWithError(th.unbindRoleHandler), web.TelemetryMW("tenant_unbind_role_handler", log)))
-	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "token"), web.Adapt(web.HandlerWithError(th.generateTokenHandler), web.TelemetryMW("tenant_generate_token_handler", log)))
-	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "revoke"), web.Adapt(web.HandlerWithError(th.revokeHandler), web.TelemetryMW("tenant_revoke_handler", log)))
+	mux.Handle(web.ProxyTenantPath, web.Adapt(web.HandlerWithError(th.tenantHandler), web.TelemetryMW("tenantHandler", log)))
+	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "bind"), web.Adapt(web.HandlerWithError(th.bindRoleHandler), web.TelemetryMW("tenantHandler", log)))
+	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "unbind"), web.Adapt(web.HandlerWithError(th.unbindRoleHandler), web.TelemetryMW("tenantHandler", log)))
+	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "token"), web.Adapt(web.HandlerWithError(th.generateTokenHandler), web.TelemetryMW("tenantHandler", log)))
+	mux.Handle(fmt.Sprintf("%s%s/", web.ProxyTenantPath, "revoke"), web.Adapt(web.HandlerWithError(th.revokeHandler), web.TelemetryMW("tenantHandler", log)))
 	th.mux = mux
 
 	return th

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -114,7 +114,7 @@ func cleanPath(pth string) string {
 func AuthMW(log *logrus.Entry, tm token.Manager) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// let sidecar refresh token go through
+			// let tenant refresh token go through
 			if r.URL.Path == "/proxy/refresh-token/" {
 				next.ServeHTTP(w, r)
 				return
@@ -138,7 +138,7 @@ func AuthMW(log *logrus.Entry, tm token.Manager) Middleware {
 				var claims token.Claims
 				parsedToken, err := tm.ParseWithClaims(tkn, JWTSigningSecret, &claims)
 				if err != nil {
-					log.Errorf("validating token: %v", err)
+					log.Debugf("validating token: %v", err)
 
 					fwd := ForwardedHeader(r)
 					pluginID := NormalizePluginID(fwd["by"])
@@ -181,7 +181,7 @@ func AuthMW(log *logrus.Entry, tm token.Manager) Middleware {
 type HandlerWithError func(w http.ResponseWriter, r *http.Request) error
 
 // ServeHTTP implements the http.Handler interface
-// This is a noop because the underlying HandlerWithError should be executed explicity
+// This is a noop because the underlying HandlerWithError should be executed explicitly
 func (h HandlerWithError) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 
 // TelemetryMW logs the time for the next handler and records the error from the next handler in the span


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

- Removes busybox from RPM deployment
- Standardize telemetry span names for karavictl handlers
- Update some comments

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manual deployment of RPM.
