### PR TITLE
[bug-985]: Update flag descriptions and move flags to relevant commands

### DIFF
--- a/cmd/karavictl/cmd/generate.go
+++ b/cmd/karavictl/cmd/generate.go
@@ -35,6 +35,20 @@ func NewGenerateCmd() *cobra.Command {
 		},
 	}
 
+	generateCmd.PersistentFlags().StringP("admin-token", "f", "", "Path to admin token file; required")
+	generateCmd.PersistentFlags().String("addr", "", "Address of the CSM Authorization Proxy Server; required")
+	generateCmd.PersistentFlags().Bool("insecure", false, "Skip certificate validation of the CSM Authorization Proxy Server")
+
+	err := generateCmd.MarkPersistentFlagRequired("admin-token")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, generateCmd.ErrOrStderr(), err)
+	}
+
+	err = generateCmd.MarkPersistentFlagRequired("addr")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, generateCmd.ErrOrStderr(), err)
+	}
+
 	generateCmd.AddCommand(NewGenerateTokenCmd())
 	return generateCmd
 }

--- a/cmd/karavictl/cmd/role.go
+++ b/cmd/karavictl/cmd/role.go
@@ -67,6 +67,20 @@ func NewRoleCmd() *cobra.Command {
 		},
 	}
 
+	roleCmd.PersistentFlags().StringP("admin-token", "f", "", "Path to admin token file; required")
+	roleCmd.PersistentFlags().String("addr", "", "Address of the CSM Authorization Proxy Server; required")
+	roleCmd.PersistentFlags().Bool("insecure", false, "Skip certificate validation of the CSM Authorization Proxy Server")
+
+	err := roleCmd.MarkPersistentFlagRequired("admin-token")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, roleCmd.ErrOrStderr(), err)
+	}
+
+	err = roleCmd.MarkPersistentFlagRequired("addr")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, roleCmd.ErrOrStderr(), err)
+	}
+
 	roleCmd.AddCommand(NewRoleCreateCmd())
 	roleCmd.AddCommand(NewRoleDeleteCmd())
 	roleCmd.AddCommand(NewRoleGetCmd())

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -58,7 +58,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -87,7 +87,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -127,7 +127,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		rootCmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -127,7 +127,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"role", "create", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_create_test.go
+++ b/cmd/karavictl/cmd/role_create_test.go
@@ -58,7 +58,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "create", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -87,7 +87,7 @@ func TestRoleCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"role", "create", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "create", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/role_delete_test.go
+++ b/cmd/karavictl/cmd/role_delete_test.go
@@ -58,7 +58,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -89,7 +89,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -130,7 +130,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		rootCmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_delete_test.go
+++ b/cmd/karavictl/cmd/role_delete_test.go
@@ -58,7 +58,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "delete", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -89,7 +89,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "delete", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -130,7 +130,7 @@ func TestRoleDeleteHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"role", "delete", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"role", "delete", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_get_test.go
+++ b/cmd/karavictl/cmd/role_get_test.go
@@ -80,7 +80,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "get", "--addr", "https://role-service.com", "--insecure", "--name", "test"})
+		cmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--name", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		got := strings.ReplaceAll(gotOutput.String(), "\n", "")
@@ -112,7 +112,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "get", "--addr", "https://role-service.com", "--insecure"})
+		cmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -153,7 +153,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "get", "--addr", "https://role-service.com", "--insecure"})
+		rootCmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_get_test.go
+++ b/cmd/karavictl/cmd/role_get_test.go
@@ -80,7 +80,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--name", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "get", "--insecure", "--name", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		got := strings.ReplaceAll(gotOutput.String(), "\n", "")
@@ -112,7 +112,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "get", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -153,7 +153,7 @@ func TestRoleGetHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"role", "get", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"role", "get", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_list_test.go
+++ b/cmd/karavictl/cmd/role_list_test.go
@@ -79,7 +79,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "list", "--addr", "https://role-service.com", "--insecure"})
+		cmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		got := strings.ReplaceAll(gotOutput.String(), "\n", "")
@@ -110,7 +110,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "list", "--addr", "https://role-service.com", "--insecure"})
+		cmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -151,7 +151,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "list", "--addr", "https://role-service.com", "--insecure"})
+		rootCmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_list_test.go
+++ b/cmd/karavictl/cmd/role_list_test.go
@@ -79,7 +79,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		got := strings.ReplaceAll(gotOutput.String(), "\n", "")
@@ -110,7 +110,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -151,7 +151,7 @@ func TestRoleListHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"role", "list", "--addr", "https://role-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"role", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_update_test.go
+++ b/cmd/karavictl/cmd/role_update_test.go
@@ -56,7 +56,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "update", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {
@@ -83,7 +83,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"role", "update", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -125,7 +125,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"role", "update", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/role_update_test.go
+++ b/cmd/karavictl/cmd/role_update_test.go
@@ -56,7 +56,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {
@@ -83,7 +83,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		cmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -125,7 +125,7 @@ func TestRoleUpdateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB"})
+		rootCmd.SetArgs([]string{"role", "update", "--addr", "https://role-service.com", "--insecure", "--role=bar=powerflex=11e4e7d35817bd0f=mypool=75GB", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/rolebinding.go
+++ b/cmd/karavictl/cmd/rolebinding.go
@@ -35,6 +35,20 @@ func NewRoleBindingCmd() *cobra.Command {
 		},
 	}
 
+	rolebindingCmd.PersistentFlags().StringP("admin-token", "f", "", "Path to admin token file; required")
+	rolebindingCmd.PersistentFlags().String("addr", "", "Address of the CSM Authorization Proxy Server; required")
+	rolebindingCmd.PersistentFlags().Bool("insecure", false, "Skip certificate validation of the CSM Authorization Proxy Server")
+
+	err := rolebindingCmd.MarkPersistentFlagRequired("admin-token")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, rolebindingCmd.ErrOrStderr(), err)
+	}
+
+	err = rolebindingCmd.MarkPersistentFlagRequired("addr")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, rolebindingCmd.ErrOrStderr(), err)
+	}
+
 	rolebindingCmd.AddCommand(NewCreateRoleBindingCmd())
 	rolebindingCmd.AddCommand(NewDeleteRoleBindingCmd())
 	return rolebindingCmd

--- a/cmd/karavictl/cmd/rolebinding_create_test.go
+++ b/cmd/karavictl/cmd/rolebinding_create_test.go
@@ -52,7 +52,7 @@ func TestRolebindingCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -78,7 +78,7 @@ func TestRolebindingCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -118,7 +118,7 @@ func TestRolebindingCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium"})
+		cmd.SetArgs([]string{"rolebinding", "create", "--tenant=MyTenant", "--role=CAMedium", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go cmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/rolebinding_delete_test.go
+++ b/cmd/karavictl/cmd/rolebinding_delete_test.go
@@ -54,7 +54,7 @@ func TestRolebindingDelete(t *testing.T) {
 		deleteRoleBindingCmd := NewDeleteRoleBindingCmd()
 
 		deleteRoleBindingCmd.SetOutput(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "delete"})
+		rootCmd.SetArgs([]string{"rolebinding", "delete", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		rootCmd.Execute()
 
 		if !gotCalled {
@@ -81,7 +81,7 @@ func TestRolebindingDelete(t *testing.T) {
 		rootCmd := NewRootCmd()
 
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "delete"})
+		rootCmd.SetArgs([]string{"rolebinding", "delete", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go rootCmd.Execute()
 		<-done
 
@@ -121,7 +121,7 @@ func TestRolebindingDelete(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "rolebinding", "delete"})
+		cmd.SetArgs([]string{"rolebinding", "delete", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go cmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/root.go
+++ b/cmd/karavictl/cmd/root.go
@@ -26,9 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
-
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 )
 
 // Common constants.
@@ -37,14 +34,8 @@ const (
 	K3sPath = "/usr/local/bin/k3s"
 )
 
-var (
-	cfgFile string
-)
-
 // NewRootCmd creates a new base command when called without any subcommands
 func NewRootCmd() *cobra.Command {
-	cobra.OnInitialize(initConfig)
-
 	rootCmd := &cobra.Command{
 		Use:   "karavictl",
 		Short: "karavictl is used to interact with karavi server",
@@ -57,11 +48,6 @@ func NewRootCmd() *cobra.Command {
 			}
 		},
 	}
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.karavictl.yaml)")
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	rootCmd.PersistentFlags().StringP("admin-token", "f", "", "Specify the admin token file")
-	rootCmd.PersistentFlags().String("addr", "", "address of the csm-authorization storage service")
-	rootCmd.PersistentFlags().Bool("insecure", false, "insecure skip verify")
 
 	rootCmd.AddCommand(NewRoleCmd())
 	rootCmd.AddCommand(NewRoleBindingCmd())
@@ -83,30 +69,6 @@ func createHTTPClient(addr string, insecure bool) (api.Client, error) {
 	}
 
 	return c, nil
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		// Search config in home directory with name ".karavictl" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".karavictl")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	_ = viper.ReadInConfig()
 }
 
 func readAccessAdminToken(admTknFile string) (string, string, error) {

--- a/cmd/karavictl/cmd/storage.go
+++ b/cmd/karavictl/cmd/storage.go
@@ -45,6 +45,20 @@ func NewStorageCmd() *cobra.Command {
 		},
 	}
 
+	storageCmd.PersistentFlags().StringP("admin-token", "f", "", "Path to admin token file; required")
+	storageCmd.PersistentFlags().String("addr", "", "Address of the CSM Authorization Proxy Server; required")
+	storageCmd.PersistentFlags().Bool("insecure", false, "Skip certificate validation of the CSM Authorization Proxy Server")
+
+	err := storageCmd.MarkPersistentFlagRequired("admin-token")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCmd.ErrOrStderr(), err)
+	}
+
+	err = storageCmd.MarkPersistentFlagRequired("addr")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, storageCmd.ErrOrStderr(), err)
+	}
+
 	storageCmd.AddCommand(NewStorageCreateCmd())
 	storageCmd.AddCommand(NewStorageDeleteCmd())
 	storageCmd.AddCommand(NewStorageGetCmd())

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -170,7 +170,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"storage", "create", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -108,7 +108,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "create", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -134,7 +134,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "create", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/storage_create_test.go
+++ b/cmd/karavictl/cmd/storage_create_test.go
@@ -108,7 +108,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure"})
+		cmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -134,7 +134,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure"})
+		cmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -170,7 +170,7 @@ func TestStorageCreateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure"})
+		rootCmd.SetArgs([]string{"storage", "create", "--addr", "https://storage-service.com", "--endpoint", "https://0.0.0.0:443", "--system-id", "testing123", "--type", "powerflex", "--user", "admin", "--password", "password", "--insecure", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_delete_test.go
+++ b/cmd/karavictl/cmd/storage_delete_test.go
@@ -58,7 +58,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "delete", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "delete", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/storage_delete_test.go
+++ b/cmd/karavictl/cmd/storage_delete_test.go
@@ -58,7 +58,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure"})
+		cmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure"})
+		cmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -121,7 +121,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "delete", "--addr", "storage-service.com", "--type=powerflex", "--insecure", "--system-id=542a2d5f5122210f"})
+		rootCmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--type=powerflex", "--insecure", "--system-id=542a2d5f5122210f", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_delete_test.go
+++ b/cmd/karavictl/cmd/storage_delete_test.go
@@ -121,7 +121,7 @@ func TestStorageDeleteHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"storage", "delete", "--addr", "storage-service.com", "--type=powerflex", "--insecure", "--system-id=542a2d5f5122210f", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"storage", "delete", "--type=powerflex", "--insecure", "--system-id=542a2d5f5122210f", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -120,7 +120,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"storage", "get", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -58,7 +58,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure"})
+		cmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure"})
+		cmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -120,7 +120,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "get", "--addr", "https://storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure"})
+		rootCmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "testing123", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_get_test.go
+++ b/cmd/karavictl/cmd/storage_get_test.go
@@ -58,7 +58,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "get", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageGetHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"storage", "get", "--addr", "https://storage-service.com", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "get", "--system-id", "11e4e7d35817bd0f", "--type", "powerflex", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -61,7 +61,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -88,7 +88,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -61,7 +61,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "storage", "list", "--addr", "storage-service.com", "--insecure"})
+		cmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -88,7 +88,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "storage", "list", "--addr", "storage-service.com", "--insecure"})
+		cmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -124,7 +124,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "afile.yaml", "storage", "list", "--addr", "storage-service.com", "--insecure"})
+		rootCmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_list_test.go
+++ b/cmd/karavictl/cmd/storage_list_test.go
@@ -124,7 +124,7 @@ func TestStorageListHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"storage", "list", "--addr", "storage-service.com", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"storage", "list", "--insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_update_test.go
+++ b/cmd/karavictl/cmd/storage_update_test.go
@@ -58,7 +58,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure"})
+		cmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure"})
+		cmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -120,7 +120,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "admin.yaml", "storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure"})
+		rootCmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_update_test.go
+++ b/cmd/karavictl/cmd/storage_update_test.go
@@ -120,7 +120,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		rootCmd.SetArgs([]string{"storage", "update", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done

--- a/cmd/karavictl/cmd/storage_update_test.go
+++ b/cmd/karavictl/cmd/storage_update_test.go
@@ -58,7 +58,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "update", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -84,7 +84,7 @@ func TestStorageUpdateHandler(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"storage", "update", "--addr", "https://storage-service.com", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
+		cmd.SetArgs([]string{"storage", "update", "--type=powerflex", "--insecure", "--endpoint=https://10.0.0.1", "--system-id=542a2d5f5122210f", "--user=admin", "--password=test", "--array-insecure", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 

--- a/cmd/karavictl/cmd/tenant.go
+++ b/cmd/karavictl/cmd/tenant.go
@@ -41,6 +41,20 @@ func NewTenantCmd() *cobra.Command {
 		},
 	}
 
+	tenantCmd.PersistentFlags().StringP("admin-token", "f", "", "Path to admin token file; required")
+	tenantCmd.PersistentFlags().String("addr", "", "Address of the CSM Authorization Proxy Server; required")
+	tenantCmd.PersistentFlags().Bool("insecure", false, "Skip certificate validation of the CSM Authorization Proxy Server")
+
+	err := tenantCmd.MarkPersistentFlagRequired("admin-token")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, tenantCmd.ErrOrStderr(), err)
+	}
+
+	err = tenantCmd.MarkPersistentFlagRequired("addr")
+	if err != nil {
+		reportErrorAndExit(JSONOutput, tenantCmd.ErrOrStderr(), err)
+	}
+
 	tenantCmd.AddCommand(NewTenantCreateCmd())
 	tenantCmd.AddCommand(NewTenantDeleteCmd())
 	tenantCmd.AddCommand(NewTenantGetCmd())

--- a/cmd/karavictl/cmd/tenant_create_test.go
+++ b/cmd/karavictl/cmd/tenant_create_test.go
@@ -56,7 +56,7 @@ func TestTenantCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "create", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "create", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {
@@ -82,7 +82,7 @@ func TestTenantCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "create", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "create", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -116,7 +116,7 @@ func TestTenantCreate(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "create"})
+		rootCmd.SetArgs([]string{"tenant", "create", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -157,7 +157,7 @@ func TestTenantCreate(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "create", "-n", "test"})
+		rootCmd.SetArgs([]string{"tenant", "create", "-n", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -189,7 +189,7 @@ func TestTenantCreate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "create", "-n", "testname", "--approvesdc", "true"})
+		cmd.SetArgs([]string{"tenant", "create", "-n", "testname", "--approvesdc", "true", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {

--- a/cmd/karavictl/cmd/tenant_delete_test.go
+++ b/cmd/karavictl/cmd/tenant_delete_test.go
@@ -52,7 +52,7 @@ func TestTenantDelete(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "delete", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "delete", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -63,6 +63,9 @@ func TestTenantDelete(t *testing.T) {
 		defer afterFn()
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return nil, errors.New("test error")
+		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
 		}
 		var gotCode int
 		done := make(chan struct{})
@@ -75,7 +78,7 @@ func TestTenantDelete(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"tenant", "delete", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "delete", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -97,6 +100,9 @@ func TestTenantDelete(t *testing.T) {
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return &mocks.FakeClient{}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -109,7 +115,7 @@ func TestTenantDelete(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "delete"})
+		rootCmd.SetArgs([]string{"tenant", "delete", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -136,6 +142,9 @@ func TestTenantDelete(t *testing.T) {
 				},
 			}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -147,7 +156,7 @@ func TestTenantDelete(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "delete", "-n", "test"})
+		rootCmd.SetArgs([]string{"tenant", "delete", "-n", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -160,7 +169,7 @@ func TestTenantDelete(t *testing.T) {
 		if err := json.NewDecoder(&gotOutput).Decode(&gotErr); err != nil {
 			t.Fatal(err)
 		}
-		wantErrMsg := "specify token file"
+		wantErrMsg := "test error"
 		if gotErr.ErrorMsg != wantErrMsg {
 			t.Errorf("got err %q, want %q", gotErr.ErrorMsg, wantErrMsg)
 		}

--- a/cmd/karavictl/cmd/tenant_get_test.go
+++ b/cmd/karavictl/cmd/tenant_get_test.go
@@ -56,7 +56,7 @@ func TestTenantGet(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile", "tenant", "get", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "get", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		var resp pb.Tenant
@@ -72,6 +72,9 @@ func TestTenantGet(t *testing.T) {
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return nil, errors.New("test error")
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -83,7 +86,7 @@ func TestTenantGet(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"tenant", "get", "-n", "testname"})
+		cmd.SetArgs([]string{"tenant", "get", "-n", "testname", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -105,6 +108,9 @@ func TestTenantGet(t *testing.T) {
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return &mocks.FakeClient{}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -117,7 +123,7 @@ func TestTenantGet(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "get"})
+		rootCmd.SetArgs([]string{"tenant", "get", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -144,6 +150,9 @@ func TestTenantGet(t *testing.T) {
 				},
 			}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -155,7 +164,7 @@ func TestTenantGet(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "get", "-n", "test"})
+		rootCmd.SetArgs([]string{"tenant", "get", "-n", "test", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -168,7 +177,7 @@ func TestTenantGet(t *testing.T) {
 		if err := json.NewDecoder(&gotOutput).Decode(&gotErr); err != nil {
 			t.Fatal(err)
 		}
-		wantErrMsg := "specify token file"
+		wantErrMsg := "test error"
 		if gotErr.ErrorMsg != wantErrMsg {
 			t.Errorf("got err %q, want %q", gotErr.ErrorMsg, wantErrMsg)
 		}

--- a/cmd/karavictl/cmd/tenant_list_test.go
+++ b/cmd/karavictl/cmd/tenant_list_test.go
@@ -57,7 +57,7 @@ func TestTenantList(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "list"})
+		cmd.SetArgs([]string{"tenant", "list", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if !gotCalled {
@@ -68,6 +68,9 @@ func TestTenantList(t *testing.T) {
 		defer afterFn()
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return nil, errors.New("test error")
+		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
 		}
 		var gotCode int
 		done := make(chan struct{})
@@ -80,7 +83,7 @@ func TestTenantList(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"tenant", "list"})
+		cmd.SetArgs([]string{"tenant", "list", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -106,6 +109,9 @@ func TestTenantList(t *testing.T) {
 				},
 			}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -119,7 +125,7 @@ func TestTenantList(t *testing.T) {
 		//tenantListCmd := NewTenantListCmd()
 
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "list"})
+		rootCmd.SetArgs([]string{"tenant", "list", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -132,7 +138,7 @@ func TestTenantList(t *testing.T) {
 		if err := json.NewDecoder(&gotOutput).Decode(&gotErr); err != nil {
 			t.Fatal(err)
 		}
-		wantErrMsg := "specify token file"
+		wantErrMsg := "test error"
 		if gotErr.ErrorMsg != wantErrMsg {
 			t.Errorf("got err %q, want %q", gotErr.ErrorMsg, wantErrMsg)
 		}

--- a/cmd/karavictl/cmd/tenant_update_test.go
+++ b/cmd/karavictl/cmd/tenant_update_test.go
@@ -56,7 +56,7 @@ func TestTenantUpdate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetOutput(&gotOutput)
-		cmd.SetArgs([]string{"--admin-token", "afile.yaml", "tenant", "update", "-n", "testname", "--approvesdc", "true"})
+		cmd.SetArgs([]string{"tenant", "update", "-n", "testname", "--approvesdc", "true", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		cmd.Execute()
 
 		if len(gotOutput.Bytes()) != 0 {
@@ -67,6 +67,9 @@ func TestTenantUpdate(t *testing.T) {
 		defer afterFn()
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return nil, errors.New("test error")
+		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
 		}
 		var gotCode int
 		done := make(chan struct{})
@@ -79,7 +82,7 @@ func TestTenantUpdate(t *testing.T) {
 
 		cmd := NewRootCmd()
 		cmd.SetErr(&gotOutput)
-		cmd.SetArgs([]string{"tenant", "update", "-n", "testname", "--approvesdc", "true"})
+		cmd.SetArgs([]string{"tenant", "update", "-n", "testname", "--approvesdc", "true", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 		go cmd.Execute()
 		<-done
 
@@ -101,6 +104,9 @@ func TestTenantUpdate(t *testing.T) {
 		CreateHTTPClient = func(addr string, insecure bool) (api.Client, error) {
 			return &mocks.FakeClient{}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -113,7 +119,7 @@ func TestTenantUpdate(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "update"})
+		rootCmd.SetArgs([]string{"tenant", "update", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -140,6 +146,9 @@ func TestTenantUpdate(t *testing.T) {
 				},
 			}, nil
 		}
+		ReadAccessAdminToken = func(afile string) (string, string, error) {
+			return "AUnumberTokenIsNotWorkingman", "AUnumberTokenIsNotWorkingman", nil
+		}
 		var gotCode int
 		done := make(chan struct{})
 		osExit = func(code int) {
@@ -151,7 +160,7 @@ func TestTenantUpdate(t *testing.T) {
 
 		rootCmd := NewRootCmd()
 		rootCmd.SetErr(&gotOutput)
-		rootCmd.SetArgs([]string{"tenant", "update", "-n", "test", "--approvesdc", "true"})
+		rootCmd.SetArgs([]string{"tenant", "update", "-n", "test", "--approvesdc", "true", "--admin-token", "admin.yaml", "--addr", "proxy.com"})
 
 		go rootCmd.Execute()
 		<-done
@@ -164,7 +173,7 @@ func TestTenantUpdate(t *testing.T) {
 		if err := json.NewDecoder(&gotOutput).Decode(&gotErr); err != nil {
 			t.Fatal(err)
 		}
-		wantErrMsg := "specify token file"
+		wantErrMsg := "test error"
 		if gotErr.ErrorMsg != wantErrMsg {
 			t.Errorf("got err %q, want %q", gotErr.ErrorMsg, wantErrMsg)
 		}


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

- Defines the `admin-token`, `addr`, and` insecure` flags only on the relevant commands (karavictl generate, storage, role, rolebinding, tenant) to accurately reflect usage
- Updates `admin-token` and `addr` as required flags for relevant commands so if the user doesn't provide them, the output is clear about it
- Removes unused functionality that was put in place by Cobra by default

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/895|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Existing unit tests updated.
