### PR TITLE
Cipher suites

### DIFF
--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -124,7 +124,18 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 			TLSClientConfig: &tls.Config{
 				RootCAs:            pool,
 				InsecureSkipVerify: false,
-				MinVersion:         tls.VersionTLS13,
+				MinVersion:         tls.VersionTLS12,
+				MaxVersion:         tls.VersionTLS13,
+				PreferServerCipherSuites: true, // Added to prefer server's cipher suite order
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, // Stronger cipher suite
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				},
+
+			  SessionTicketsDisabled: true, // Disable session tickets if not needed for added security
 			},
 		}
 	}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -112,6 +112,8 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 		pi.rp.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				tlsConfig.MinVersion = tls.VersionTLS12,
+				tlsConfig.MaxVersion = tls.VersionTLS13,
 			},
 		}
 	} else {
@@ -134,8 +136,6 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 				},
-
-			  SessionTicketsDisabled: true, // Disable session tickets if not needed for added security
 			},
 		}
 	}

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -465,7 +465,7 @@ func getRootCertificatePool(log *logrus.Entry) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// It will return set of Secure CipherSuites
+// GetSecuredCipherSuites returns a set of secure cipher suites.
 func GetSecuredCipherSuites() (suites []uint16) {
 	securedSuite := tls.CipherSuites()
 	for _, v := range securedSuite {

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -112,6 +112,9 @@ func (pi *ProxyInstance) Start(proxyHost, access, refresh string) error {
 		pi.rp.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS12,
+				MaxVersion:         tls.VersionTLS13,
+				CipherSuites:       GetSecuredCipherSuites(),
 			},
 		}
 	} else {
@@ -274,6 +277,9 @@ func run(log *logrus.Entry) error {
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{tlsCert},
 		InsecureSkipVerify: true, // #nosec G402
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       GetSecuredCipherSuites(),
 	}
 
 	var proxyInstances []*ProxyInstance
@@ -345,6 +351,9 @@ func refreshTokens(proxyHost url.URL, refreshToken string, accessToken *string, 
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS12,
+				MaxVersion:         tls.VersionTLS13,
+				CipherSuites:       GetSecuredCipherSuites(),
 			},
 		}
 	} else {

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -465,6 +465,7 @@ func getRootCertificatePool(log *logrus.Entry) (*x509.CertPool, error) {
 	return pool, nil
 }
 
+// It will return set of Secure CipherSuites
 func GetSecuredCipherSuites() (suites []uint16) {
 	securedSuite := tls.CipherSuites()
 	for _, v := range securedSuite {


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
PowerScale and Authorization use not recommended Cipher Suites to communicate


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Verified the all cipher suite in A grade now 
![image](https://github.com/dell/karavi-authorization/assets/109663924/846d8936-12ca-4da9-b53d-b93012346ebd)


