### PR TITLE
[bug-1347]: Prompt for storage system password when creating storage

### DIFF
--- a/cmd/karavictl/cmd/storage_create.go
+++ b/cmd/karavictl/cmd/storage_create.go
@@ -23,6 +23,7 @@ import (
 	"karavi-authorization/internal/web"
 	"karavi-authorization/pb"
 	"net/http"
+	"net/url"
 	"strings"
 	"syscall"
 
@@ -140,6 +141,18 @@ func NewStorageCreateCmd() *cobra.Command {
 			adminTknBody := token.AdminToken{
 				Refresh: refreshToken,
 				Access:  accessToken,
+			}
+
+			urlWithUser, err := url.Parse(input.Endpoint)
+			if err != nil {
+				errAndExit(err)
+			}
+
+			urlWithUser.Scheme = "https"
+			urlWithUser.User = url.User(input.User)
+
+			if !cmd.Flags().Lookup("password").Changed {
+				readPassword(cmd.ErrOrStderr(), fmt.Sprintf("Enter password for %v: ", urlWithUser), &input.Password)
 			}
 
 			if err := doStorageCreateRequest(context.Background(), addr, input, insecure, cmd, adminTknBody); err != nil {


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

Add storage system password prompt when creating storage if password flag is not provided.

```
karavictl storage create --type powerflex --endpoint https://powerflex.com --system-id 0123456789 --user admin --admin-token admin.yaml --insecure --addr csm-authorization.com --array-insecure
Enter password for https://admin@powerflex.com:
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1347|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

New unit test. Manual testing with real storage system.
