### PR TITLE
[bug-1356]: Add csm-authorization string to Forwarded header

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
-          skip-list: "karavi-authorization/deploy,karavi-authorization/internal/web,karavi-authorization/internal/tenantsvc,karavi-authorization/cmd/karavictl/cmd,karavi-authorization/cmd/proxy-server,karavi-authorization/cmd/tenant-service,karavi-authorization/internal/proxy,karavi-authorization/internal/tenantsvc,karavi-authorization/internal/token/jwx,karavi-authorization/internal/k8s,karavi-authorization/internal/role-service,karavi-authorization/internal/role-service/validate"
+          skip-list: "karavi-authorization/deploy,karavi-authorization/internal/web,karavi-authorization/internal/tenantsvc,karavi-authorization/cmd/karavictl/cmd,karavi-authorization/cmd/proxy-server,karavi-authorization/cmd/tenant-service,karavi-authorization/internal/proxy,karavi-authorization/internal/tenantsvc,karavi-authorization/internal/token/jwx,karavi-authorization/internal/k8s,karavi-authorization/internal/role-service,karavi-authorization/internal/role-service/validate,karavi-authorization/cmd/sidecar-proxy"
         env:
           # The hostname used to communicate with the Redis service container
           REDIS_HOST: redis

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,3 +28,4 @@ jobs:
         with:
           version: latest
           skip-cache: true
+          args: --out-format=colored-line-number

--- a/cmd/sidecar-proxy/main.go
+++ b/cmd/sidecar-proxy/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -159,8 +159,8 @@ func (pi *ProxyInstance) Handler(proxyHost url.URL, access, refresh string) http
 		// intended endpoint.
 		// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
 		r.Host = proxyHost.Host
-		r.Header.Add(HeaderForwarded, fmt.Sprintf("for=%s;%s", pi.IntendedEndpoint, pi.SystemID))
-		r.Header.Add(HeaderForwarded, fmt.Sprintf("by=%s", pi.PluginID))
+		r.Header.Add(HeaderForwarded, fmt.Sprintf("for=csm-authorization;%s;%s", pi.IntendedEndpoint, pi.SystemID))
+		r.Header.Add(HeaderForwarded, fmt.Sprintf("by=csm-authorization;%s", pi.PluginID))
 		pi.log.WithFields(logrus.Fields{
 			"proxy_host": proxyHost.Host,
 			"path":       r.URL.Path,

--- a/cmd/sidecar-proxy/main_test.go
+++ b/cmd/sidecar-proxy/main_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestProxyInstanceHandler(t *testing.T) {
 	t.Run("it adds to the Forwarded header", func(t *testing.T) {
-		fakeProxyServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fakeProxyServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer fakeProxyServer.Close()

--- a/cmd/sidecar-proxy/main_test.go
+++ b/cmd/sidecar-proxy/main_test.go
@@ -1,0 +1,75 @@
+// Copyright © 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestProxyInstanceHandler(t *testing.T) {
+	t.Run("it adds to the Forwarded header", func(t *testing.T) {
+		fakeProxyServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer fakeProxyServer.Close()
+
+		u, err := url.Parse(fakeProxyServer.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rp := httputil.NewSingleHostReverseProxy(u)
+		rp.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+
+		pi := &ProxyInstance{
+			log:              logrus.NewEntry(logrus.New()),
+			PluginID:         "powerflex",
+			IntendedEndpoint: "https://powerflex.com",
+			SystemID:         "542a2d5f5122210f",
+			rp:               rp,
+		}
+
+		handler := pi.Handler(*u, "access", "refresh")
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(w, r)
+
+		fwd := r.Header.Values("Forwarded")
+
+		fwdFor := fwd[0]
+		want := "for=csm-authorization;https://powerflex.com;542a2d5f5122210f"
+		if fwdFor != want {
+			t.Errorf("got %s, want %s", fwdFor, want)
+		}
+
+		fwdBy := fwd[1]
+		want = "by=csm-authorization;powerflex"
+		if fwdBy != want {
+			t.Errorf("got %s, want %s", fwdFor, want)
+		}
+	})
+}

--- a/internal/proxy/dispatch_handler_test.go
+++ b/internal/proxy/dispatch_handler_test.go
@@ -76,7 +76,7 @@ func testConfiguredDispatchHandler(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 	checkError(t, err)
-	r.Header.Set("Forwarded", "by=powerflex")
+	r.Header.Set("Forwarded", "by=csm-authorization;powerflex")
 	h.ServeHTTP(w, r)
 
 	t.Log("Then I should get back a 200 response")
@@ -100,14 +100,14 @@ func testForwardedHeaders(t *testing.T) {
 		func(t *testing.T) *http.Request {
 			r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 			checkError(t, err)
-			r.Header.Add("Forwarded", "by=powerflex,for=https://1.1.1.1;7045c4cc20dffc0f")
+			r.Header.Add("Forwarded", "by=csm-authorization;powerflex,for=csm-authorization;https://1.1.1.1;7045c4cc20dffc0f")
 			return r
 		},
 		func(t *testing.T) *http.Request {
 			r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 			checkError(t, err)
-			r.Header.Add("Forwarded", "for=https://1.1.1.1;7045c4cc20dffc0f")
-			r.Header.Add("Forwarded", "by=powerflex")
+			r.Header.Add("Forwarded", "for=csm-authorization;https://1.1.1.1;7045c4cc20dffc0f")
+			r.Header.Add("Forwarded", "by=csm-authorization;powerflex")
 			return r
 		},
 	}

--- a/internal/proxy/dispatch_handler_test.go
+++ b/internal/proxy/dispatch_handler_test.go
@@ -100,12 +100,6 @@ func testForwardedHeaders(t *testing.T) {
 		func(t *testing.T) *http.Request {
 			r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 			checkError(t, err)
-			r.Header.Add("Forwarded", "by=csm-authorization;powerflex,for=csm-authorization;https://1.1.1.1;7045c4cc20dffc0f")
-			return r
-		},
-		func(t *testing.T) *http.Request {
-			r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-			checkError(t, err)
 			r.Header.Add("Forwarded", "for=csm-authorization;https://1.1.1.1;7045c4cc20dffc0f")
 			r.Header.Add("Forwarded", "by=csm-authorization;powerflex")
 			return r

--- a/internal/proxy/dispatch_handler_test.go
+++ b/internal/proxy/dispatch_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proxy/powerflex_handler_test.go
+++ b/internal/proxy/powerflex_handler_test.go
@@ -62,8 +62,8 @@ func TestPowerFlex(t *testing.T) {
 		}))
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
 		// Create the PowerFlex handler and configure it with a system
@@ -123,8 +123,8 @@ func TestPowerFlex(t *testing.T) {
 		}))
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=https://%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;https://%s;542a2d5f5122210f", fakePowerFlex.URL))
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
 		// Create the PowerFlex handler and configure it with a system
@@ -273,13 +273,13 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		rVolCreate.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolCreate.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		rVolDel.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolDel.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolDel.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolDel.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
@@ -461,12 +461,12 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		rVolCreate.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolCreate.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rVolCreate.Header.Add(proxy.HeaderPVName, createBody.Name)
 
-		rVolMap.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolMap.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolMap.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolMap.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
@@ -667,15 +667,15 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		rVolCreate.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolCreate.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolCreate.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rVolCreate.Header.Add(proxy.HeaderPVName, createBody.Name)
 
-		rVolMap.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolMap.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolMap.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolMap.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
-		rVolUnmap.Header.Add("Forwarded", "by=csi-vxflexos")
-		rVolUnmap.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		rVolUnmap.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		rVolUnmap.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
@@ -818,8 +818,8 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=https://%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;https://%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rtr := newTestRouter()
 
 		// Create a PowerFlexHandler and update it with the fake PowerFlex
@@ -961,8 +961,8 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=https://%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;https://%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rtr := newTestRouter()
 
 		// Create a PowerFlexHandler and update it with the fake PowerFlex
@@ -1100,8 +1100,8 @@ func TestPowerFlex(t *testing.T) {
 
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=https://%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;https://%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rtr := newTestRouter()
 
 		rdb := testCreateRedisInstance(t)
@@ -1245,8 +1245,8 @@ func TestPowerFlex(t *testing.T) {
 		}))
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;%s;542a2d5f5122210f", fakePowerFlex.URL))
 
 		// Create the router and assign the appropriate handlers.
 		rtr := newTestRouter()
@@ -1395,8 +1395,8 @@ func TestPowerFlex(t *testing.T) {
 		}))
 		// Add headers that the sidecar-proxy would add, in order to identify
 		// the request as intended for a PowerFlex with the given systemID.
-		r.Header.Add("Forwarded", "by=csi-vxflexos")
-		r.Header.Add("Forwarded", fmt.Sprintf("for=https://%s;542a2d5f5122210f", fakePowerFlex.URL))
+		r.Header.Add("Forwarded", "by=csm-authorization;csi-vxflexos")
+		r.Header.Add("Forwarded", fmt.Sprintf("for=csm-authorization;https://%s;542a2d5f5122210f", fakePowerFlex.URL))
 		rtr := newTestRouter()
 
 		rdb := testCreateRedisInstance(t)

--- a/internal/proxy/powerflex_handler_test.go
+++ b/internal/proxy/powerflex_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proxy/powermax_handler_test.go
+++ b/internal/proxy/powermax_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proxy/powermax_handler_test.go
+++ b/internal/proxy/powermax_handler_test.go
@@ -48,7 +48,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 			}),
 		)
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		w := httptest.NewRecorder()
 
 		go func() {
@@ -65,7 +65,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 	t.Run("it returns 502 Bad Gateway on unknown system", func(t *testing.T) {
 		sut := buildPowerMaxHandler(t)
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;0000000000") // pass unknown system ID
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;0000000000") // pass unknown system ID
 		w := httptest.NewRecorder()
 
 		sut.ServeHTTP(w, r)
@@ -95,7 +95,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet,
 			"/univmax/restapi/100/sloprovisioning/symmetrix/1234567890/storagegroup/csi-CSM-Bronze-SRP_1-SG/",
 			nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
@@ -147,7 +147,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPut,
 			"/univmax/restapi/91/sloprovisioning/symmetrix/1234567890/storagegroup/csi-CSM-Bronze-SRP_1-SG/",
 			bytes.NewReader(payloadBytes))
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
@@ -212,7 +212,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPut,
 			"/univmax/restapi/91/sloprovisioning/symmetrix/1234567890/volume/003E4/",
 			bytes.NewReader(payloadBytes))
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 
@@ -282,7 +282,7 @@ func testPowerMaxServeHTTP(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPut,
 			"/univmax/restapi/91/sloprovisioning/symmetrix/1234567890/storagegroup/csi-CSM-Bronze-SRP_1-SG/",
 			bytes.NewReader(payloadBytes))
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;ttps://1.1.1.1;1234567890")
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 

--- a/internal/proxy/powerscale_handler_test.go
+++ b/internal/proxy/powerscale_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proxy/powerscale_handler_test.go
+++ b/internal/proxy/powerscale_handler_test.go
@@ -77,7 +77,7 @@ func testPowerScaleServeHTTP(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		w := httptest.NewRecorder()
 
 		go func() {
@@ -94,7 +94,7 @@ func testPowerScaleServeHTTP(t *testing.T) {
 	t.Run("it returns 502 Bad Gateway on unknown system", func(t *testing.T) {
 		sut := buildPowerScaleHandler(t)
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;0000000000") // pass unknown system ID
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;0000000000") // pass unknown system ID
 		w := httptest.NewRecorder()
 
 		sut.ServeHTTP(w, r)
@@ -144,7 +144,7 @@ func testPowerScaleServeHTTP(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet,
 			"/test/endpoint",
 			nil)
-		r.Header.Set("Forwarded", "for=https://1.1.1.1;1234567890")
+		r.Header.Set("Forwarded", "for=csm-authorization;https://1.1.1.1;1234567890")
 		addJWTToRequestHeader(t, r)
 		w := httptest.NewRecorder()
 

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -215,18 +215,18 @@ func timeSince(start time.Time, fName string, log *logrus.Entry) {
 
 // ForwardedHeader splits forward headers for verification
 func ForwardedHeader(r *http.Request) map[string]string {
-	// Forwarded: for=foo by=bar -> map[for] = foo
+	// Forwarded: for=10.0.0.1;host=ingress.com for=csm-authorization;https://10.0.0.1;12345 by=csm-authorization;powerflex
+	// -> map[for] = https://10.0.0.1;12345; map[by] = powerflex
 	fwd := r.Header["Forwarded"]
 
-	if len(fwd) > 0 {
-		if strings.Contains(fwd[0], ",for") {
-			fwd = strings.Split(fwd[0], ",")
-		}
-	}
-	m := make(map[string]string, len(fwd))
+	m := make(map[string]string)
 	for _, e := range fwd {
-		split := strings.Split(e, "=")
-		m[split[0]] = split[1]
+		if strings.Contains(e, "csm-authorization;") {
+			split := strings.Split(strings.ReplaceAll(e, "csm-authorization;", ""), "=")
+			if len(split) >= 2 {
+				m[split[0]] = split[1]
+			}
+		}
 	}
 	return m
 }

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+// Copyright © 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -213,6 +214,48 @@ func TestAuthMW(t *testing.T) {
 			t.Errorf("expected next handler to be executed")
 		}
 	})
+}
+
+func TestFowardedHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *http.Request
+		want    map[string]string
+	}{
+		{
+			name: "it parses the csm-authorization values",
+			request: &http.Request{
+				Header: http.Header{
+					"Forwarded": []string{"for=csm-authorization;https://10.0.0.1;12345", "by=csm-authorization;powerflex"},
+				},
+			},
+			want: map[string]string{
+				"for": "https://10.0.0.1;12345",
+				"by":  "powerflex",
+			},
+		},
+		{
+			name: "it parses the csm-authorization values with another for value",
+			request: &http.Request{
+				Header: http.Header{
+					"Forwarded": []string{"for=10.0.0.1;host=ingress.com", "for=csm-authorization;https://10.0.0.1;12345", "by=csm-authorization;powerflex"},
+				},
+			},
+			want: map[string]string{
+				"for": "https://10.0.0.1;12345",
+				"by":  "powerflex",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := web.ForwardedHeader(test.request)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %v, want %v", got, test.want)
+			}
+		})
+	}
 }
 
 func discardLogger() *logrus.Entry {


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description

Add `csm-authorization` to Forwarded header for the proxy-server to parse header values specifically sent by the Authorization sidecar.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1356|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

New unit tests. Manual integration style test.
