### PR TITLE
Support multiple sidecar headers in the Authorization Proxy Server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export BUILDER_TAG ?= 1.11.0
-export SIDECAR_TAG ?= 1.11.0
+export BUILDER_TAG ?= 1.14.0
+export SIDECAR_TAG ?= 1.14.0
 
 # figure out if podman or docker should be used (use podman if found)
 ifneq (, $(shell which podman 2>/dev/null))
@@ -27,7 +27,7 @@ export VERSION = $(call dot-delimiter, ${BUILDER_TAG}, 1).$(call dot-delimiter, 
 export RELEASE = $(call dot-delimiter, ${BUILDER_TAG}, 3)
 
 ifeq (${RELEASE},)
-	VERSION=1.11
+	VERSION=1.14
 	RELEASE=0
 endif
 

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
       - name: opa
-        image: docker.io/openpolicyagent/opa
+        image: docker.io/openpolicyagent/opa:0.70.0
         imagePullPolicy: IfNotPresent
         args:
         - "run"
@@ -281,7 +281,7 @@ spec:
         configMap:
           name: csm-config-params
 ---
-apiVersion: apps/v1 
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-primary

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -215,6 +215,9 @@ func timeSince(start time.Time, fName string, log *logrus.Entry) {
 
 // ForwardedHeader splits forward headers for verification
 func ForwardedHeader(r *http.Request) map[string]string {
+	// Forwarded header can either be
+	// Forwarded: for=https://10.0.0.1;12345 by=powerflex
+	// Or
 	// Forwarded: for=10.0.0.1;host=ingress.com for=csm-authorization;https://10.0.0.1;12345 by=csm-authorization;powerflex
 	// -> map[for] = https://10.0.0.1;12345; map[by] = powerflex
 	fwd := r.Header["Forwarded"]
@@ -223,6 +226,11 @@ func ForwardedHeader(r *http.Request) map[string]string {
 	for _, e := range fwd {
 		if strings.Contains(e, "csm-authorization;") {
 			split := strings.Split(strings.ReplaceAll(e, "csm-authorization;", ""), "=")
+			if len(split) >= 2 {
+				m[split[0]] = split[1]
+			}
+		} else {
+			split := strings.Split(e, "=")
 			if len(split) >= 2 {
 				m[split[0]] = split[1]
 			}

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -246,6 +246,18 @@ func TestFowardedHeader(t *testing.T) {
 				"by":  "powerflex",
 			},
 		},
+		{
+			name: "it parses without csm-authorization values",
+			request: &http.Request{
+				Header: http.Header{
+					"Forwarded": []string{"for=https://10.0.0.1;12345", "by=powerflex"},
+				},
+			},
+			want: map[string]string{
+				"for": "https://10.0.0.1;12345",
+				"by":  "powerflex",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/scripts/install_karavi_auth.sh
+++ b/scripts/install_karavi_auth.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Copyright (c) 2022-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -93,6 +93,7 @@ fi
 if [ $UPGRADE == 1 ]; then
     $K3S kubectl -n kube-system delete helmcharts.helm.cattle.io traefik
     rpm -Uvh ${RPM_FILE} --nopreun --nopostun
+    $K3S kubectl -n karavi set image deployment/proxy-server opa=docker.io/openpolicyagent/opa:0.70.0
 else
     if getenforce | grep -q 'Enforcing\|Permissive'; then
         set -e


### PR DESCRIPTION
<!--
Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
-->
# Description
Support multiple sidecar headers in the Authorization Proxy Server

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1804|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] 1.12.1 RPM proxy with 1.10 driver/sidecar
- [x] 1.12.1 RPM proxy with 1.12 driver/sidecar
- [x] upgrade 1.10 -> 1.12.1 RPM proxy with 1.10 driver/sidecar
- make test
```
podman run --rm -it -v /root/csm/karavi-authorization/policies:/policies/ openpolicyagent/opa:0.70.0 test -v /policies/
/policies/volumes_create_test.rego:
data.karavi.volumes.create.test_small_request_allowed: PASS (1.705892ms)
data.karavi.volumes.create.test_large_request_not_allowed: PASS (384.792µs)
--------------------------------------------------------------------------------
PASS: 2/2
go test -count=1 -cover -race -timeout 30s -short ./...
        karavi-authorization/cmd/karavictl              coverage: 0.0% of statements
        karavi-authorization/cmd/karavictl/cmd/api/mocks                coverage: 0.0% of statements
        karavi-authorization/cmd/role-service           coverage: 0.0% of statements
ok      karavi-authorization/cmd/karavictl/cmd  1.196s  coverage: 50.8% of statements
ok      karavi-authorization/cmd/karavictl/cmd/api      1.107s  coverage: 57.0% of statements
        karavi-authorization/cmd/storage-service                coverage: 0.0% of statements
        karavi-authorization/internal/decision          coverage: 0.0% of statements
ok      karavi-authorization/cmd/proxy-server   3.542s  coverage: 26.0% of statements
ok      karavi-authorization/cmd/sidecar-proxy  1.135s  coverage: 5.2% of statements
ok      karavi-authorization/cmd/tenant-service 1.058s  coverage: 7.3% of statements
ok      karavi-authorization/deploy     1.195s  coverage: 84.3% of statements
ok      karavi-authorization/internal/k8s       1.123s  coverage: 51.0% of statements
        karavi-authorization/internal/role-service/mocks                coverage: 0.0% of statements
ok      karavi-authorization/internal/powerflex 10.281s coverage: 91.4% of statements
ok      karavi-authorization/internal/proxy     9.831s  coverage: 72.5% of statements
ok      karavi-authorization/internal/quota     1.169s  coverage: 90.2% of statements
ok      karavi-authorization/internal/role-service      1.057s  coverage: 80.0% of statements
ok      karavi-authorization/internal/role-service/middleware   1.063s  coverage: 74.2% of statements
ok      karavi-authorization/internal/role-service/roles        1.060s  coverage: 87.4% of statements
ok      karavi-authorization/internal/role-service/validate     1.208s  coverage: 77.5% of statements
ok      karavi-authorization/internal/sdc       1.051s  coverage: 96.8% of statements
        karavi-authorization/internal/storage-service/mocks             coverage: 0.0% of statements
        karavi-authorization/internal/tenantsvc/mocks           coverage: 0.0% of statements
ok      karavi-authorization/internal/storage-service   2.645s  coverage: 92.1% of statements
ok      karavi-authorization/internal/storage-service/middleware        1.073s  coverage: 100.0% of statements
ok      karavi-authorization/internal/tenantsvc 3.402s  coverage: 79.2% of statements
ok      karavi-authorization/internal/tenantsvc/middleware      1.324s  coverage: 77.7% of statements
ok      karavi-authorization/internal/token     1.074s  coverage: 95.5% of statements
        karavi-authorization/pb         coverage: 0.0% of statements
ok      karavi-authorization/internal/token/jwx 1.069s  coverage: 75.2% of statements
ok      karavi-authorization/internal/web       1.060s  coverage: 65.9% of statements

```
